### PR TITLE
Correct example agent name to use correct casing in line with n8n

### DIFF
--- a/nodejs/n8n/sample-agent/src/n8nClient.ts
+++ b/nodejs/n8n/sample-agent/src/n8nClient.ts
@@ -75,10 +75,10 @@ export class N8nClient {
 
   public async invokeAgentWithScope(userMessage: string, fromUser: string = '') {
     const agentDetails = { agentId: process.env.AGENT_ID || 'sample-agent' };
-    
+
     const invokeAgentDetails: InvokeAgentDetails = {
       ...agentDetails,
-      agentName: 'N8N Agent',
+      agentName: 'n8n Agent',
     };
 
     const tenantDetails: TenantDetails = {


### PR DESCRIPTION
This pull request makes a minor update to the agent's name in the example to ensure consistency with n8n branding.