### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-dotnet-semantickernel-sampleagent.yml
+++ b/.github/workflows/ci-dotnet-semantickernel-sampleagent.yml
@@ -1,4 +1,6 @@
 name: CI - Build .NET Semantic Kernel Sample Agent
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Agent365-Samples/security/code-scanning/1](https://github.com/microsoft/Agent365-Samples/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block setting minimal required permissions, as close as possible to where they are relevant. In this case, the workflow merely checks out the repository and builds code, so it only needs read permissions on repository contents. The `permissions: contents: read` block should be added at the workflow root level (after the `name:` field and before the `on:` block), which will apply to all jobs in this workflow. No further changes are necessary to methods, imports, or existing workflow steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
