### PR TITLE
Fix agentic user token retrieval for n8n Sample

### DIFF
--- a/nodejs/n8n/sample-agent/.env.template
+++ b/nodejs/n8n/sample-agent/.env.template
@@ -16,17 +16,14 @@ PORT=3978
 MCP_AUTH_TOKEN=
 TOOLS_MODE=MCPPlatform
 
-# Service Connection Settings
-connections__service_connection__settings__clientId=
-connections__service_connection__settings__clientSecret=
-connections__service_connection__settings__tenantId=
+#Auth
+connections__service_connection__settings__clientId=blueprint_id
+connections__service_connection__settings__clientSecret=blueprint_secret
+connections__service_connection__settings__tenantId=tenant_id
 
-# Set service connection as default
-connectionsMap__0__serviceUrl=*
 connectionsMap__0__connection=service_connection
+connectionsMap__0__serviceUrl=*
 
-# AgenticAuthentication Options
 agentic_type=agentic
-agentic_altBlueprintConnectionName=service_connection
-agentic_scopes=ea9ffc3e-8a23-4a7d-836d-234d7c7565c1/.default # Prod Agentic scope
+agentic_scopes=https://graph.microsoft.com/.default
 agentic_connectionName=service_connection

--- a/nodejs/n8n/sample-agent/Agent-Code-Walkthrough.MD
+++ b/nodejs/n8n/sample-agent/Agent-Code-Walkthrough.MD
@@ -110,14 +110,12 @@ TOOLS_MODE=MCPPlatform
 - Handles graceful shutdown on SIGINT/SIGTERM signals
 
 #### agent.ts - Agent Application Setup
-- Defines conversation state interface (`ConversationState` with message count)
 - Creates `AgentApplication` with memory storage and file download support
 - Registers activity handlers:
-  - **Message Activity**: Increments counter, delegates to `N8nAgent.handleAgentMessageActivity`
+  - **Message Activity**: Delegates to `N8nAgent.handleAgentMessageActivity`
   - **InstallationUpdate Activity**: Delegates to `N8nAgent.handleInstallationUpdateActivity`
 
 #### n8nAgent.ts - Core Business Logic
-- Manages agent state: `isApplicationInstalled` and `termsAndConditionsAccepted`
 - **Message Handler**: Enforces installation → terms acceptance → processing flow
 - **Installation Handler**: Sets state flags and sends welcome/goodbye messages
 - **Notification Handlers**: Processes email and Word @-mention notifications with two-stage flow (metadata extraction → content retrieval via n8n)
@@ -152,19 +150,6 @@ TOOLS_MODE=MCPPlatform
 - **n8nClient.ts**: External integration
 - **mcpToolRegistrationService.ts**: Tool management
 - **telemetry.ts**: Observability configuration
-
-### Lifecycle State Management
-```typescript
-// Installation → Terms → Active → Uninstall
-isApplicationInstalled: false → true → true → false
-termsAndConditionsAccepted: false → false → true → false
-```
-
-**Flow**:
-1. User installs agent → Welcome message
-2. User sends "I accept" → Terms accepted
-3. User sends messages → Forwarded to n8n
-4. Answer is sent back to user
 
 ### Observability-First Design
 - All n8n invocations wrapped with InvokeAgentScope

--- a/nodejs/n8n/sample-agent/package.json
+++ b/nodejs/n8n/sample-agent/package.json
@@ -13,19 +13,20 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@microsoft/agents-hosting": "^1.1.0-alpha.85",
     "@microsoft/agents-hosting-express": "^1.1.0-alpha.85",
     "@microsoft/agents-a365-notifications": "*",
     "@microsoft/agents-a365-observability": "*",
     "@microsoft/agents-a365-runtime": "*",
     "@microsoft/agents-a365-tooling": "*",
-    "@modelcontextprotocol/sdk": "^1.18.1",
+    "@modelcontextprotocol/sdk": "^1.22.0",
     "express": "^5.1.0",
-    "dotenv": "^17.2.2"
+    "dotenv": "^17.2.3"
   },
   "devDependencies": {
-    "tsx": "^4.20.5",
-    "@microsoft/m365agentsplayground": "^0.2.18",
-    "@types/node": "^24.5.1",
-    "typescript": "^5.0.0"
+    "tsx": "^4.20.6",
+    "@microsoft/m365agentsplayground": "^0.2.20",
+    "@types/node": "^24.10.1",
+    "typescript": "^5.9.3"
   }
 }

--- a/nodejs/n8n/sample-agent/src/agent.ts
+++ b/nodejs/n8n/sample-agent/src/agent.ts
@@ -1,31 +1,24 @@
-import { TurnState, AgentApplication, AttachmentDownloader, MemoryStorage, TurnContext } from '@microsoft/agents-hosting';
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TurnState, AgentApplicationBuilder, MemoryStorage, TurnContext } from '@microsoft/agents-hosting';
 import { ActivityTypes } from '@microsoft/agents-activity';
 import { N8nAgent } from './n8nAgent';
 
-interface ConversationState {
-  count: number;
-}
-type ApplicationTurnState = TurnState<ConversationState>
-
-const downloader = new AttachmentDownloader();
 const storage = new MemoryStorage();
 
-export const agentApplication = new AgentApplication<ApplicationTurnState>({
-  storage,
-  fileDownloaders: [downloader]
-});
+export const agentApplication =
+  new AgentApplicationBuilder<TurnState>()
+    .withAuthorization({ agentic: {} })
+    .withStorage(storage)
+    .build();
 
-const n8nAgent = new N8nAgent();
+const n8nAgent = new N8nAgent(agentApplication);
 
-agentApplication.onActivity(ActivityTypes.Message, async (context: TurnContext, state: ApplicationTurnState) => {
-  // Increment count state
-  let count = state.conversation.count ?? 0;
-  state.conversation.count = ++count;
-
+agentApplication.onActivity(ActivityTypes.Message, async (context: TurnContext, state: TurnState) => {
   await n8nAgent.handleAgentMessageActivity(context, state);
 });
 
-agentApplication.onActivity(ActivityTypes.InstallationUpdate, async (context: TurnContext, state: ApplicationTurnState) => {
+agentApplication.onActivity(ActivityTypes.InstallationUpdate, async (context: TurnContext, state: TurnState) => {
   await n8nAgent.handleInstallationUpdateActivity(context, state);
 });
-

--- a/nodejs/n8n/sample-agent/src/index.ts
+++ b/nodejs/n8n/sample-agent/src/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import express, { Response } from 'express';
 import 'dotenv/config';
 import { AuthConfiguration, authorizeJWT, CloudAdapter, loadAuthConfigFromEnv, Request } from '@microsoft/agents-hosting';
@@ -5,7 +8,7 @@ import { observabilityManager } from './telemetry';
 import { agentApplication } from './agent';
 
 const authConfig: AuthConfiguration = loadAuthConfigFromEnv();
-const adapter = new CloudAdapter(authConfig);
+const adapter = agentApplication.adapter as CloudAdapter;
 const app = express();
 const port = process.env.PORT ?? 3978;
 
@@ -23,7 +26,7 @@ app.post('/api/messages', async (req: Request, res: Response) => {
 });
 
 const server = app.listen(port, () => {
-  console.log(`\nServer listening to port ${port} for appId ${authConfig.clientId} debug ${process.env.DEBUG}`);
+  console.log(`\nServer listening to port ${port} for appId ${authConfig.clientId} debug ${!!process.env.DEBUG}`);
 }).on('error', async (err) => {
   console.error(err);
   await observabilityManager.shutdown();
@@ -40,7 +43,6 @@ process.on('SIGINT', () => {
     process.exit(0);
   });
 });
-
 
 process.on('SIGTERM', () => {
   server.close(() => {

--- a/nodejs/n8n/sample-agent/src/mcpToolRegistrationService.ts
+++ b/nodejs/n8n/sample-agent/src/mcpToolRegistrationService.ts
@@ -1,8 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { McpToolServerConfigurationService, McpClientTool, MCPServerConfig } from '@microsoft/agents-a365-tooling';
-import { AgenticAuthenticationService, Authorization, Utility as RuntimeUtility } from '@microsoft/agents-a365-runtime';
+import { AgenticAuthenticationService, Utility as RuntimeUtility } from '@microsoft/agents-a365-runtime';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { TurnContext } from '@microsoft/agents-hosting';
+import { AgentApplication, TurnContext, TurnState } from '@microsoft/agents-hosting';
 
 export type McpServer = MCPServerConfig & {
   type: string,
@@ -22,12 +25,14 @@ export class McpToolRegistrationService {
   async getMcpServers(
     authHandlerName: string,
     turnContext: TurnContext,
+    agentApplication: AgentApplication<TurnState>,
     authToken: string
   ): Promise<McpServer[]> {
-    const authorization = turnContext.turnState.get('authorization');
     if (!authToken) {
+      const authorization = agentApplication.authorization;
       authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext);
     }
+
    // Get the agentic user ID from authorization configuration
     const agenticAppId = RuntimeUtility.ResolveAgentIdentity(turnContext, authToken);
 

--- a/nodejs/n8n/sample-agent/src/n8nClient.ts
+++ b/nodejs/n8n/sample-agent/src/n8nClient.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { InferenceScope, InvokeAgentScope, TenantDetails, InvokeAgentDetails, InferenceOperationType } from '@microsoft/agents-a365-observability';
 import { McpServer } from './mcpToolRegistrationService';
 

--- a/nodejs/n8n/sample-agent/src/telemetry.ts
+++ b/nodejs/n8n/sample-agent/src/telemetry.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import {
   ObservabilityManager,
 } from '@microsoft/agents-a365-observability';


### PR DESCRIPTION
This PR fixes the Agentic User Token retrieval in mcpToolRegistrationService.ts by getting the Authorization entity from the Agent Application instead of the TurnContext.

Beyond that I've taken the opportunity to simplify the sample agent, update dependencies and tidy up the environment template file