### PR TITLE
Changed the server's host from `localhost` to `0.0.0.0`

### DIFF
--- a/python/agent-framework/sample-agent/host_agent_server.py
+++ b/python/agent-framework/sample-agent/host_agent_server.py
@@ -332,12 +332,12 @@ class GenericAgentHost:
         print(f"🏢 {self.agent_class.__name__}")
         print("=" * 80)
         print(f"🔒 Auth: {'Enabled' if auth_configuration else 'Anonymous'}")
-        print(f"🚀 Server: localhost:{port}")
+        print(f"🚀 Server: Listening on 0.0.0.0:{port} (all interfaces)")
         print(f"📚 Endpoint: http://localhost:{port}/api/messages")
         print(f"❤️  Health: http://localhost:{port}/api/health\n")
 
         try:
-            run_app(app, host="localhost", port=port, handle_signals=True)
+            run_app(app, host="0.0.0.0", port=port, handle_signals=True)
         except KeyboardInterrupt:
             print("\n👋 Server stopped")
 


### PR DESCRIPTION
This pull request updates the server startup behavior to improve accessibility for external clients. The server now listens on all network interfaces instead of just localhost, making it reachable from outside the host machine.

Server accessibility improvements:
* Changed the server's host from `localhost` to `0.0.0.0` in both the startup log message and the `run_app` call, allowing connections from any network interface.