### PR TITLE
fix dependency on agent-framework sample app

### DIFF
--- a/python/agent-framework/sample-agent/pyproject.toml
+++ b/python/agent-framework/sample-agent/pyproject.toml
@@ -7,7 +7,8 @@ authors = [
 ]
 dependencies = [
     # AgentFramework SDK - The official package
-    "agent-framework-azure-ai",
+    "agent-framework-azure-ai==1.0.0b251114",
+    "agent-framework-core==1.0.0b251114",
     
     # Azure AI Projects - explicitly require pre-release version
     "azure-ai-agents>=1.2.0b5",
@@ -15,9 +16,11 @@ dependencies = [
 
     # Microsoft Agents SDK - Official packages for hosting and integration
     "microsoft-agents-hosting-aiohttp",
-    "microsoft-agents-hosting-core",
+    "microsoft-agents-hosting-core>= 0.4.0",
     "microsoft-agents-authentication-msal",
-    "microsoft-agents-activity",
+    "microsoft-agents-activity>= 0.4.0",
+
+    "opentelemetry-semantic-conventions-ai==0.4.13",
 
     # Azure SDK components
     "azure-identity",


### PR DESCRIPTION
**Issue**
The sample apps does not use fixed dependencies.

**Solution**
Pin the dependencies to the version defined in constraints file

https://github.com/[microsoft/Agent365-python](https://github.com/microsoft/Agent365-python/blob/main/pyproject.toml#L68)/blob/main/pyproject.toml#L68

This specific issue also occurred because agent-framework has a hard dependency on semantic conventions. The agent365 SDK should consider pinning the semantic convention version when using agent-framework like in agent-framework tooling extention