### PR TITLE
Specify versions for agent-framework packages

### DIFF
--- a/python/agent-framework/sample-agent/pyproject.toml
+++ b/python/agent-framework/sample-agent/pyproject.toml
@@ -7,7 +7,8 @@ authors = [
 ]
 dependencies = [
     # AgentFramework SDK - The official package
-    "agent-framework-azure-ai",
+    "agent-framework-core==1.0.0b260128",
+    "agent-framework-azure-ai==1.0.0b260128",
     
     # Azure AI Projects - explicitly require pre-release version
     "azure-ai-agents>=1.2.0b5",


### PR DESCRIPTION
Because the latest Agent Framework includes breaking changes, this sample no longer works when imported. As a temporary workaround, I changed Agent Framework to a version from before those breaking changes.