### PR TITLE
Fix Devin sample agent: observability v2 migration, runtime crashes, and deployment issues

### DIFF
--- a/nodejs/devin/sample-agent/package.json
+++ b/nodejs/devin/sample-agent/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node --env-file=.env dist/index.js",
+    "start": "node dist/index.js",
     "test-tool": "agentsplayground"
   },
   "engines": {
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@microsoft/m365agentsplayground": "^0.2.20",
+    "@types/express": "^5.0.6",
     "typescript": "^5.9.2"
   }
 }

--- a/nodejs/devin/sample-agent/src/agent.ts
+++ b/nodejs/devin/sample-agent/src/agent.ts
@@ -8,7 +8,9 @@ import {
   InferenceOperationType,
   InferenceScope,
   InvokeAgentScope,
+  InvokeAgentScopeDetails,
   ObservabilityManager,
+  Request,
   TenantDetails,
 } from "@microsoft/agents-a365-observability";
 import { ClusterCategory } from "@microsoft/agents-a365-runtime";
@@ -93,15 +95,21 @@ export class A365Agent extends AgentApplication<ApplicationTurnState> {
         const baggageScope = new BaggageBuilder()
           .tenantId(tenantDetails.tenantId)
           .agentId(invokeAgentDetails.agentId)
-          .correlationId(uuidv4())
           .agentName(invokeAgentDetails.agentName)
           .conversationId(context.activity.conversation?.id)
           .build();
 
         await baggageScope.run(async () => {
+          const request: Request = {
+            conversationId: context.activity.conversation?.id,
+            sessionId: context.activity.conversation?.id,
+            content: context.activity.text || undefined,
+          };
+          const invokeScopeDetails: InvokeAgentScopeDetails = {};
           const invokeAgentScope = InvokeAgentScope.start(
-            invokeAgentDetails,
-            tenantDetails
+            request,
+            invokeScopeDetails,
+            { ...invokeAgentDetails, tenantId: tenantDetails.tenantId }
           );
 
           await invokeAgentScope.withActiveSpanAsync(async () => {
@@ -197,50 +205,62 @@ export class A365Agent extends AgentApplication<ApplicationTurnState> {
 
     startTypingLoop();
 
+    let inferenceScope!: ReturnType<typeof InferenceScope.start>;
     try {
       const inferenceDetails: InferenceDetails = {
         operationName: InferenceOperationType.CHAT,
         model: "claude-3-7-sonnet-20250219",
         providerName: "cognition-ai",
         inputTokens: Math.ceil(userMessage.length / 4), // Rough estimate
-        responseId: `resp-${Date.now()}`,
         outputTokens: 0, // Will be updated after response
         finishReasons: undefined,
       };
 
-      const inferenceScope = InferenceScope.start(
+      inferenceScope = InferenceScope.start(
+        { conversationId: turnContext.activity.conversation?.id },
         inferenceDetails,
-        agentDetails,
-        tenantDetails
+        { ...agentDetails, tenantId: agentDetails.tenantId || tenantDetails.tenantId }
       );
       inferenceScope.recordInputMessages([userMessage]);
 
+      const chunks: string[] = [];
+      let streamErrorMessage: string | undefined;
       let totalResponseLength = 0;
       const responseStream = new Stream()
-        .on("data", async (chunk) => {
-          totalResponseLength += (chunk as string).length;
-          invokeAgentScope.recordOutputMessages([`LLM Response: ${chunk}`]);
-          inferenceScope.recordOutputMessages([`LLM Response: ${chunk}`]);
-          await turnContext.sendActivity(chunk);
+        .on("data", (chunk) => {
+          const text = chunk as string;
+          totalResponseLength += text.length;
+          chunks.push(text);
+          invokeAgentScope.recordOutputMessages([`LLM Response: ${text}`]);
+          inferenceScope.recordOutputMessages([`LLM Response: ${text}`]);
         })
-        .on("error", async (error) => {
+        .on("error", (error) => {
+          streamErrorMessage = String(error);
           invokeAgentScope.recordOutputMessages([`Streaming error: ${error}`]);
           inferenceScope.recordOutputMessages([`Streaming error: ${error}`]);
-          await turnContext.sendActivity(error);
         })
         .on("close", () => {
-          inferenceScope.recordOutputTokens(Math.ceil(totalResponseLength / 4)); // Rough estimate
+          inferenceScope.recordOutputTokens(Math.ceil(totalResponseLength / 4));
           inferenceScope.recordFinishReasons(["stop"]);
         });
 
       await devinClient.invokeAgent(userMessage, responseStream);
+      stopTypingLoop();
+      if (streamErrorMessage) {
+        await turnContext.sendActivity("There was an error processing your request, please try again.");
+      } else if (chunks.length > 0) {
+        await turnContext.sendActivity(chunks.join("\n\n"));
+      } else {
+        await turnContext.sendActivity("Devin did not return a response. Please try again.");
+      }
     } catch (error) {
+      stopTypingLoop();
       invokeAgentScope.recordOutputMessages([`LLM error: ${error}`]);
       await turnContext.sendActivity(
         "There was an error processing your request"
       );
     } finally {
-      stopTypingLoop();
+      inferenceScope?.dispose();
     }
   }
 

--- a/nodejs/devin/sample-agent/src/agent.ts
+++ b/nodejs/devin/sample-agent/src/agent.ts
@@ -189,6 +189,7 @@ export class A365Agent extends AgentApplication<ApplicationTurnState> {
     // Each sendActivity call produces a discrete Teams message.
     // NOTE: For Teams agentic identities, streaming is buffered into a single message by the SDK;
     //       use sendActivity for any messages that must arrive immediately.
+    
     await turnContext.sendActivity('Got it — working on it…');
 
     // Typing indicator loop — refreshes the "..." animation every ~4s for long-running operations.

--- a/nodejs/devin/sample-agent/src/devin-client.ts
+++ b/nodejs/devin/sample-agent/src/devin-client.ts
@@ -146,7 +146,8 @@ export class DevinClient implements Client {
           const messageContent = String(latestMessage?.message);
           responseStream.emit("data", messageContent);
           sentMessages.add(latestMessage.event_id);
-          console.debug(`emit data event with content: ${messageContent}}`);
+          console.debug(`emit data event with content: ${messageContent}`);
+          break;
         }
       }
     }

--- a/nodejs/devin/sample-agent/src/index.ts
+++ b/nodejs/devin/sample-agent/src/index.ts
@@ -33,7 +33,7 @@ const server = app
       `\nServer listening to port ${port} for appId ${authConfig.clientId} debug ${process.env.DEBUG}`
     );
   })
-  .on("error", async (err) => {
+  .on("error", async (err: Error) => {
     console.error(err);
     process.exit(1);
   })

--- a/nodejs/devin/sample-agent/src/utils.ts
+++ b/nodejs/devin/sample-agent/src/utils.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT License.
 
 import {
-  ExecutionType,
-  InvokeAgentDetails,
+  AgentDetails,
   TenantDetails,
 } from "@microsoft/agents-a365-observability";
 import { TurnContext } from "@microsoft/agents-hosting";
 
 // Helper functions to extract agent and tenant details from context
-export function getAgentDetails(context: TurnContext): InvokeAgentDetails {
+export function getAgentDetails(context: TurnContext): AgentDetails {
   // Extract agent ID from activity recipient - use agenticAppId (camelCase, not underscore)
   const agentId =
     (context.activity.recipient as any)?.agenticAppId ||
@@ -30,12 +29,6 @@ export function getAgentDetails(context: TurnContext): InvokeAgentDetails {
       (context.activity.recipient as any)?.name ||
       process.env.AGENT_NAME ||
       "Devin Agent Sample",
-    conversationId: context.activity.conversation?.id,
-    request: {
-      content: context.activity.text || "Unknown text",
-      executionType: ExecutionType.HumanToAgent,
-      sessionId: context.activity.conversation?.id,
-    },
   };
 }
 

--- a/nodejs/devin/sample-agent/tsconfig.json
+++ b/nodejs/devin/sample-agent/tsconfig.json
@@ -16,5 +16,6 @@
       "rootDir": "src",
       "outDir": "dist",
       "tsBuildInfoFile": "dist/.tsbuildinfo"
-  }
+  },
+  "exclude": ["publish", "dist", "node_modules"]
 }


### PR DESCRIPTION


### Summary

Updates the `nodejs/devin/sample-agent` to compile and run correctly against `@microsoft/agents-a365-observability` v2 breaking API changes, fixes multiple runtime crashes discovered during App Service deployment, and addresses code quality issues.

### Changes

#### src/agent.ts
- **L4–L15**: Updated imports — added `InvokeAgentScopeDetails` (L11), `Request` (L13)
  *Reason: v2 SDK renamed/removed these types; `InvokeAgentScope.start()` now requires `InvokeAgentScopeDetails` and `Request` instead of the old positional args.*
- **L98–L103**: Removed `.correlationId(uuidv4())` from `BaggageBuilder` chain
  *Reason: `.correlationId()` method was removed in the v2 SDK.*
- **L103–L107**: Added `Request` object with `conversationId`, `sessionId`, `content`
  *Reason: v2 SDK requires a `Request` object as the first argument to scope `.start()` methods; `conversationId` moved here from `AgentDetails`.*
- **L108**: Added `InvokeAgentScopeDetails` typed variable
  *Reason: v2 SDK requires this as the second argument to `InvokeAgentScope.start()`.*
- **L110–L112**: Updated `InvokeAgentScope.start()` to new 3-arg signature with `tenantId` merged into `agentDetails`
  *Reason: v2 SDK changed the signature from `(agentDetails, tenantDetails)` to `(request, scopeDetails, agentDetails)` and moved `tenantId` onto `AgentDetails`.*
- **L208**: Hoisted `inferenceScope` declaration with definite assignment assertion (`let inferenceScope!:`) before `try`
  *Reason: Allows `finally` block to call `inferenceScope?.dispose()` even when an exception is thrown inside `try`.*
- **L215–L222**: Removed `responseId` field from `InferenceDetails`
  *Reason: `responseId` was moved to `InferenceResponse` in v2 and is no longer accepted on `InferenceDetails`.*
- **L219**: Updated `InferenceScope.start()` to new 3-arg signature
  *Reason: v2 SDK changed the signature from `(inferenceDetails, agentDetails, tenantDetails)` to `(conversationId, inferenceDetails, agentDetails)`.*
- **L231–L250**: Made stream `data`/`error`/`close` handlers synchronous; chunks collected into an array
  *Reason: `Stream.emit()` is synchronous — async handlers' returned promises are silently discarded. Calling `turnContext.sendActivity()` inside an async handler raced against turn-context proxy revocation, causing "Cannot perform 'set' on a proxy that has been revoked" crashes.*
- **L248–L255**: Send collected response via `sendActivity` after `invokeAgent` resolves
  *Reason: The turn context is still valid at this point; sending here avoids the revoked-proxy crash.*
- **L257**: `catch` block calls `stopTypingLoop()` before sending error message
  *Reason: Ensures the typing indicator stops even on error paths.*
- **L263**: `finally` block calls `inferenceScope?.dispose()`
  *Reason: Previously `dispose()` was only called on the happy path; an exception would leak the scope.*

#### src/utils.ts
- **L5**: Replaced `InvokeAgentDetails` and `ExecutionType` import with `AgentDetails`
  *Reason: `InvokeAgentDetails` type was removed in v2; `AgentDetails` is the replacement.*
- **L11**: `getAgentDetails()` return type changed to `AgentDetails`
  *Reason: Matches the new v2 type.*
- **L31**: Removed `conversationId` and `request` fields from return value
  *Reason: These fields moved to the `Request` interface in v2 and are no longer part of `AgentDetails`.*

#### src/index.ts
- **L36**: Added `Error` type annotation to `err` parameter
  *Reason: TypeScript strict mode requires an explicit type; without it the implicit `any` caused a compilation error.*

#### src/devin-client.ts
- **L150**: Added `break` after emitting a `devin_message` event
  *Reason: `DevinSessionStatus` only includes `new`/`claimed`/`running`; Devin stays in `running` after replying, so without the `break` the poll loop ran until the 5-minute timeout, and the agent never returned a response.*

#### package.json
- **L7**: Changed `start` script from `node --env-file=.env dist/index.js` to `node dist/index.js`
  *Reason: App Service doesn't have a `.env` file — env vars come from Application Settings. `--env-file=.env` crashed on startup with "file not found".*
- **L28**: Added `@types/express` to `devDependencies`
  *Reason: Missing type definitions caused TypeScript compilation errors for Express types.*

#### tsconfig.json
- **L20**: Added `"exclude": ["publish", "dist", "node_modules"]`
  *Reason: Without this, `tsc` tried to compile `.ts` files (or `.json` with `resolveJsonModule`) inside `publish/` and `dist/`, causing duplicate identifier and type errors.*

### Testing

- `npm run build` passes with zero errors
- Verified stream handler behavior: chunks are collected synchronously, then sent as a single `sendActivity` call after `invokeAgent` resolves
- Confirmed polling exits after first Devin reply