### PR TITLE
feat: update Node.js samples to MCP V2 per-audience token model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,10 @@ coverage/
 a365.config.json
 a365.generated.config.json
 app.zip
+app_logs.zip
+app_logs/
 publish/
+manifest/
 
 # OS-specific files
 .DS_Store

--- a/nodejs/claude/sample-agent/.env.template
+++ b/nodejs/claude/sample-agent/.env.template
@@ -3,6 +3,9 @@ ANTHROPIC_API_KEY=
 
 # MCP Tooling Configuration
 BEARER_TOKEN=
+# V2 per-server bearer tokens (dev mode — SDK reads BEARER_TOKEN_<SERVER_NAME_UPPER>)
+BEARER_TOKEN_MCP_MAILTOOLS=
+BEARER_TOKEN_MCP_CALENDARTOOLS=
 
 # Enable to use observability exporter, default is false which means using console exporter
 ENABLE_A365_OBSERVABILITY_EXPORTER=false

--- a/nodejs/claude/sample-agent/ToolingManifest.json
+++ b/nodejs/claude/sample-agent/ToolingManifest.json
@@ -1,19 +1,11 @@
 {
   "mcpServers": [
     {
-      "mcpServerName": "mcp_MailTools",
-      "mcpServerUniqueName": "mcp_MailTools",
-      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_MailTools",
-      "scope": "Tools.ListInvoke.All",
-      "audience": "24b71c94-d291-44af-ac1e-a396e6837fd3",
-      "publisher": "Microsoft"
-    },
-    {
       "mcpServerName": "mcp_CalendarTools",
       "mcpServerUniqueName": "mcp_CalendarTools",
-      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_CalendarTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_CalendarTools",
       "scope": "Tools.ListInvoke.All",
-      "audience": "19ec8e8a-5f2f-4e00-9f66-d3e5b4c3e201",
+      "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
       "publisher": "Microsoft"
     }
   ]

--- a/nodejs/claude/sample-agent/ToolingManifest.json
+++ b/nodejs/claude/sample-agent/ToolingManifest.json
@@ -3,16 +3,18 @@
     {
       "mcpServerName": "mcp_MailTools",
       "mcpServerUniqueName": "mcp_MailTools",
-      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_MailTools",
-      "scope": "McpServers.Mail.All",
-      "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1"
+      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_MailTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "24b71c94-d291-44af-ac1e-a396e6837fd3",
+      "publisher": "Microsoft"
     },
     {
-      "mcpServerName": "mcp_WordServer",
-      "mcpServerUniqueName": "mcp_WordServer",
-      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_WordServer",
-      "scope": "McpServers.Word.All",
-      "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1"
+      "mcpServerName": "mcp_CalendarTools",
+      "mcpServerUniqueName": "mcp_CalendarTools",
+      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_CalendarTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "19ec8e8a-5f2f-4e00-9f66-d3e5b4c3e201",
+      "publisher": "Microsoft"
     }
   ]
 }

--- a/nodejs/langchain/sample-agent/.env.example
+++ b/nodejs/langchain/sample-agent/.env.example
@@ -12,6 +12,9 @@ OPENAI_MODEL=gpt-4o
 
 # MCP Tooling Configuration
 BEARER_TOKEN=
+# V2 per-server bearer tokens (dev mode — SDK reads BEARER_TOKEN_<SERVER_NAME_UPPER>)
+BEARER_TOKEN_MCP_MAILTOOLS=
+BEARER_TOKEN_MCP_CALENDARTOOLS=
 
 # MCPPlatform Configuration. Default to production values.
 MCP_PLATFORM_ENDPOINT=

--- a/nodejs/langchain/sample-agent/ToolingManifest.json
+++ b/nodejs/langchain/sample-agent/ToolingManifest.json
@@ -3,9 +3,18 @@
     {
       "mcpServerName": "mcp_MailTools",
       "mcpServerUniqueName": "mcp_MailTools",
-      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_MailTools",
-      "scope": "McpServers.Mail.All",
-      "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1"
+      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_MailTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "24b71c94-d291-44af-ac1e-a396e6837fd3",
+      "publisher": "Microsoft"
+    },
+    {
+      "mcpServerName": "mcp_CalendarTools",
+      "mcpServerUniqueName": "mcp_CalendarTools",
+      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_CalendarTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "19ec8e8a-5f2f-4e00-9f66-d3e5b4c3e201",
+      "publisher": "Microsoft"
     }
   ]
 }

--- a/nodejs/langchain/sample-agent/ToolingManifest.json
+++ b/nodejs/langchain/sample-agent/ToolingManifest.json
@@ -1,19 +1,11 @@
 {
   "mcpServers": [
     {
-      "mcpServerName": "mcp_MailTools",
-      "mcpServerUniqueName": "mcp_MailTools",
-      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_MailTools",
-      "scope": "Tools.ListInvoke.All",
-      "audience": "24b71c94-d291-44af-ac1e-a396e6837fd3",
-      "publisher": "Microsoft"
-    },
-    {
       "mcpServerName": "mcp_CalendarTools",
       "mcpServerUniqueName": "mcp_CalendarTools",
-      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_CalendarTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_CalendarTools",
       "scope": "Tools.ListInvoke.All",
-      "audience": "19ec8e8a-5f2f-4e00-9f66-d3e5b4c3e201",
+      "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
       "publisher": "Microsoft"
     }
   ]

--- a/nodejs/openai/sample-agent/.env.template
+++ b/nodejs/openai/sample-agent/.env.template
@@ -13,6 +13,9 @@ AZURE_OPENAI_API_VERSION=2024-10-21
 
 # MCP Tooling Configuration
 BEARER_TOKEN=
+# V2 per-server bearer tokens (dev mode — SDK reads BEARER_TOKEN_<SERVER_NAME_UPPER>)
+BEARER_TOKEN_MCP_MAILTOOLS=
+BEARER_TOKEN_MCP_CALENDARTOOLS=
 
 # Enable to use observability exporter, default is false which means using console exporter
 ENABLE_A365_OBSERVABILITY_EXPORTER=false

--- a/nodejs/openai/sample-agent/ToolingManifest.json
+++ b/nodejs/openai/sample-agent/ToolingManifest.json
@@ -3,16 +3,18 @@
     {
       "mcpServerName": "mcp_MailTools",
       "mcpServerUniqueName": "mcp_MailTools",
-      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_MailTools",
-      "scope": "McpServers.Mail.All",
-      "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1"
+      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_MailTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "24b71c94-d291-44af-ac1e-a396e6837fd3",
+      "publisher": "Microsoft"
     },
     {
       "mcpServerName": "mcp_CalendarTools",
       "mcpServerUniqueName": "mcp_CalendarTools",
-      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_CalendarTools",
-      "scope": "McpServers.Calendar.All",
-      "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1"
+      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_CalendarTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "19ec8e8a-5f2f-4e00-9f66-d3e5b4c3e201",
+      "publisher": "Microsoft"
     }
   ]
 }

--- a/nodejs/openai/sample-agent/ToolingManifest.json
+++ b/nodejs/openai/sample-agent/ToolingManifest.json
@@ -1,19 +1,11 @@
 {
   "mcpServers": [
     {
-      "mcpServerName": "mcp_MailTools",
-      "mcpServerUniqueName": "mcp_MailTools",
-      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_MailTools",
-      "scope": "Tools.ListInvoke.All",
-      "audience": "24b71c94-d291-44af-ac1e-a396e6837fd3",
-      "publisher": "Microsoft"
-    },
-    {
       "mcpServerName": "mcp_CalendarTools",
       "mcpServerUniqueName": "mcp_CalendarTools",
-      "url": "https://test.agent365.svc.cloud.dev.microsoft/agents/servers/mcp_CalendarTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_CalendarTools",
       "scope": "Tools.ListInvoke.All",
-      "audience": "19ec8e8a-5f2f-4e00-9f66-d3e5b4c3e201",
+      "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
       "publisher": "Microsoft"
     }
   ]


### PR DESCRIPTION
- Update ToolingManifest.json for openai, claude, langchain samples:
  - V2 URLs (test.agent365.svc.cloud.dev.microsoft)
  - Unified scope: Tools.ListInvoke.All
  - Per-server audience GUIDs (Mail: 24b71c94, Calendar: 19ec8e8a)
  - Add publisher field
  - Replace mcp_WordServer with mcp_CalendarTools (claude)
  - Add mcp_CalendarTools entry (langchain)
- Add BEARER_TOKEN_MCP_MAILTOOLS and BEARER_TOKEN_MCP_CALENDARTOOLS to all three .env.template/.env.example files for V2 dev-mode token acquisition
- Add app_logs.zip, app_logs/, manifest/ to .gitignore