### PR TITLE
Add V2 per-audience MCP token support to .NET samples

### DIFF
--- a/dotnet/agent-framework/sample-agent/Agent/MyAgent.cs
+++ b/dotnet/agent-framework/sample-agent/Agent/MyAgent.cs
@@ -361,14 +361,15 @@ namespace Agent365AgentFrameworkSampleAgent.Agent
                     {
                         await context.StreamingResponse.QueueInformativeUpdateAsync("Loading tools...");
 
-                        // For the bearer token (development) flow, pass the token as an override and
-                        // use OboAuthHandlerName (or fall back to AgenticAuthHandlerName) as the handler.
+                        // The SDK's token provider (AgenticMcpTokenProvider in production,
+                        // DevMcpTokenProvider in dev) resolves per-server tokens automatically:
+                        // - Dev:  reads BEARER_TOKEN_<SERVER_NAME> (V2) or BEARER_TOKEN (V1 fallback)
+                        // - Prod: performs per-audience OBO exchange for each V2 server
                         var handlerForMcp = !string.IsNullOrEmpty(authHandlerName)
                             ? authHandlerName
                             : OboAuthHandlerName ?? AgenticAuthHandlerName ?? string.Empty;
-                        var tokenOverride = string.IsNullOrEmpty(authHandlerName) ? accessToken : null;
 
-                        var a365Tools = await toolService.GetMcpToolsAsync(agentId, UserAuthorization, handlerForMcp, context, tokenOverride).ConfigureAwait(false);
+                        var a365Tools = await toolService.GetMcpToolsAsync(agentId, UserAuthorization, handlerForMcp, context).ConfigureAwait(false);
 
                         if (a365Tools != null && a365Tools.Count > 0)
                         {

--- a/dotnet/agent-framework/sample-agent/Properties/launchSettings.json
+++ b/dotnet/agent-framework/sample-agent/Properties/launchSettings.json
@@ -2,32 +2,32 @@
   "profiles": {
     "Sample Agent": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "SKIP_TOOLING_ON_ERRORS": "true"
       },
-      "applicationUrl": "https://localhost:64896;http://localhost:64897"
+      "applicationUrl": "http://localhost:3978"
     },
     "Sample Agent with Bearer Token Support": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "BEARER_TOKEN": "",
         "SKIP_TOOLING_ON_ERRORS": "true"
       },
-      "applicationUrl": "https://localhost:64896;http://localhost:64897"
+      "applicationUrl": "http://localhost:3978"
     },
     "Sample Agent with V2 Bearer Token Support": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "BEARER_TOKEN": "",
         "SKIP_TOOLING_ON_ERRORS": "true"
       },
-      "applicationUrl": "https://localhost:64896;http://localhost:64897"
+      "applicationUrl": "http://localhost:3978"
     }
   }
 }

--- a/dotnet/agent-framework/sample-agent/appsettings.json
+++ b/dotnet/agent-framework/sample-agent/appsettings.json
@@ -1,4 +1,9 @@
 {
+  // V2 MCP per-server dev tokens: set BEARER_TOKEN_<UPPERCASE_SERVER_NAME> environment variables.
+  // Run: a365 develop get-token  (writes these automatically for all configured servers)
+  // The SDK reads BEARER_TOKEN_<SERVER_NAME> for each V2 server and falls back to BEARER_TOKEN for V1.
+  // Example for a server named "MailTools": BEARER_TOKEN_MAILTOOLS=<token>
+
   "AgentApplication": {
     "StartTypingTimer": false,
     "RemoveRecipientMention": false,

--- a/dotnet/semantic-kernel/sample-agent/Agents/Agent365Agent.cs
+++ b/dotnet/semantic-kernel/sample-agent/Agents/Agent365Agent.cs
@@ -56,12 +56,6 @@ public class Agent365Agent
         return _agent;
     }
 
-    public static bool TryGetBearerTokenForDevelopment(out string? bearerToken)
-    {
-        bearerToken = Environment.GetEnvironmentVariable("BEARER_TOKEN");
-        return !string.IsNullOrEmpty(bearerToken);
-    }
-
     /// <summary>
     /// Checks if graceful fallback to bare LLM mode is enabled when MCP tools fail to load.
     /// This is only allowed in Development environment AND when SKIP_TOOLING_ON_ERRORS is explicitly set to "true".
@@ -103,16 +97,11 @@ public class Agent365Agent
 
             try
             {
-                if (TryGetBearerTokenForDevelopment(out var bearerToken))
-                {
-                    // Development mode: Use bearer token from environment variable for simplified local testing
-                    await toolService.AddToolServersToAgentAsync(kernel, userAuthorization, authHandlerName, turnContext, bearerToken);
-                }
-                else
-                {
-                    // Production mode: Use standard authentication flow (Client Credentials, Managed Identity, or Federated Credentials)
-                    await toolService.AddToolServersToAgentAsync(kernel, userAuthorization, authHandlerName, turnContext);
-                }
+                // The SDK's token provider (AgenticMcpTokenProvider in production,
+                // DevMcpTokenProvider in dev) resolves per-server tokens automatically:
+                // - Dev:  reads BEARER_TOKEN_<SERVER_NAME> (V2) or BEARER_TOKEN (V1 fallback)
+                // - Prod: performs per-audience OBO exchange for each V2 server
+                await toolService.AddToolServersToAgentAsync(kernel, userAuthorization, authHandlerName, turnContext);
             }
             catch (Exception ex)
             {

--- a/dotnet/semantic-kernel/sample-agent/appsettings.json
+++ b/dotnet/semantic-kernel/sample-agent/appsettings.json
@@ -14,6 +14,11 @@
     "TenantId": "{{TenantId}}"
   },
 
+  // V2 MCP per-server dev tokens: set BEARER_TOKEN_<UPPERCASE_SERVER_NAME> environment variables.
+  // Run: a365 develop get-token  (writes these automatically for all configured servers)
+  // The SDK reads BEARER_TOKEN_<SERVER_NAME> for each V2 server and falls back to BEARER_TOKEN for V1.
+  // Example for a server named "MailTools": BEARER_TOKEN_MAILTOOLS=<token>
+
   "AgentApplication": {
     "StartTypingTimer": false,
     "RemoveRecipientMention": false,


### PR DESCRIPTION
- Remove explicit bearer token pass-through in SK Agent365Agent.cs and AF MyAgent.cs; SDK now selects DevMcpTokenProvider (reads BEARER_TOKEN_<SERVER_NAME> for V2, BEARER_TOKEN fallback for V1) or AgenticMcpTokenProvider automatically
- Add V2 bearer token dev profile to SK launchSettings.json
- Create Properties/launchSettings.json for agent-framework sample with V1/V2 profiles
- Document BEARER_TOKEN_<SERVER_NAME> convention in both appsettings.json