### PR TITLE
feat(nodejs): use @microsoft/opentelemetry distro for observability

### DIFF
--- a/nodejs/langchain/sample-agent/Agent-Code-Walkthrough.md
+++ b/nodejs/langchain/sample-agent/Agent-Code-Walkthrough.md
@@ -120,18 +120,11 @@ import { ClientConfig } from '@langchain/mcp-adapters';
 import { McpToolRegistrationService } from '@microsoft/agents-a365-tooling-extensions-langchain';
 
 import {
-  ObservabilityManager,
   InferenceScope,
-  Builder,
 } from '@microsoft/agents-a365-observability';
 
-const sdk = ObservabilityManager.configure(
-  (builder: Builder) =>
-    builder
-      .withService('TypeScript Sample Agent', '1.0.0')
-);
-
-sdk.start();
+// Observability is initialized by the Microsoft OpenTelemetry distro in index.ts.
+// See: https://github.com/microsoft/opentelemetry-distro-javascript
 
 const toolService = new McpToolRegistrationService();
 ```

--- a/nodejs/langchain/sample-agent/package.json
+++ b/nodejs/langchain/sample-agent/package.json
@@ -33,6 +33,7 @@
     "@microsoft/agents-a365-tooling-extensions-langchain": "^0.2.0-preview.1",
     "@microsoft/agents-activity": "^1.2.2",
     "@microsoft/agents-hosting": "^1.2.2",
+    "@microsoft/opentelemetry": "^0.1.0-alpha.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "langchain": "^1.0.1",

--- a/nodejs/langchain/sample-agent/src/client.ts
+++ b/nodejs/langchain/sample-agent/src/client.ts
@@ -11,40 +11,19 @@ import { Authorization, TurnContext } from '@microsoft/agents-hosting';
 
 // Observability Imports
 import {
-  ObservabilityManager,
   InferenceScope,
-  Builder,
   InferenceOperationType,
   AgentDetails,
   InferenceDetails,
   Request,
-  Agent365ExporterOptions,
 } from '@microsoft/agents-a365-observability';
-import { AgenticTokenCacheInstance } from '@microsoft/agents-a365-observability-hosting';
-import { tokenResolver } from './token-cache';
 
 export interface Client {
   invokeInferenceScope(prompt: string): Promise<string>;
 }
 
-export const a365Observability = ObservabilityManager.configure((builder: Builder) => {
-  const exporterOptions = new Agent365ExporterOptions();
-  exporterOptions.maxQueueSize = 10;
-
-  builder
-    .withService('TypeScript Sample Agent', '1.0.0')
-    .withExporterOptions(exporterOptions);
-
-  if (process.env.Use_Custom_Resolver === 'true') {
-    builder.withTokenResolver(tokenResolver);
-  } else {
-    builder.withTokenResolver((agentId: string, tenantId: string) =>
-      AgenticTokenCacheInstance.getObservabilityToken(agentId, tenantId)
-    );
-  }
-});
-
-a365Observability.start();
+// Observability is initialized by the Microsoft OpenTelemetry distro in index.ts.
+// See: https://github.com/microsoft/opentelemetry-distro-javascript
 
 const toolService = new McpToolRegistrationService();
 

--- a/nodejs/langchain/sample-agent/src/index.ts
+++ b/nodejs/langchain/sample-agent/src/index.ts
@@ -23,7 +23,7 @@ useMicrosoftOpenTelemetry({
       : (agentId: string, tenantId: string) => AgenticTokenCacheInstance.getObservabilityToken(agentId, tenantId) ?? '',
   },
   instrumentationOptions: {
-    langchain: true,
+    langchain: {},
   },
 });
 

--- a/nodejs/langchain/sample-agent/src/index.ts
+++ b/nodejs/langchain/sample-agent/src/index.ts
@@ -1,7 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // It is important to load environment variables before importing other modules
 import { configDotenv } from 'dotenv';
 
 configDotenv();
+
+// Initialize Microsoft OpenTelemetry distro for observability.
+// Must be called before importing other modules so instrumentations can patch libraries.
+// See: https://github.com/microsoft/opentelemetry-distro-javascript
+import { useMicrosoftOpenTelemetry } from '@microsoft/opentelemetry';
+import { tokenResolver } from './token-cache';
+import { AgenticTokenCacheInstance } from '@microsoft/agents-a365-observability-hosting';
+
+useMicrosoftOpenTelemetry({
+  a365: {
+    enabled: true,
+    // When Use_Custom_Resolver is true the sample populates a local token cache;
+    // otherwise agent.ts refreshes tokens into AgenticTokenCacheInstance.
+    tokenResolver: process.env.Use_Custom_Resolver === 'true'
+      ? (agentId: string, tenantId: string) => tokenResolver(agentId, tenantId) ?? ''
+      : (agentId: string, tenantId: string) => AgenticTokenCacheInstance.getObservabilityToken(agentId, tenantId) ?? '',
+  },
+  instrumentationOptions: {
+    langchain: true,
+  },
+});
 
 import { AuthConfiguration, authorizeJWT, CloudAdapter, loadAuthConfigFromEnv, Request } from '@microsoft/agents-hosting';
 import express, { Response, Express } from 'express'


### PR DESCRIPTION
Replace ObservabilityManager.configure() from @microsoft/agents-a365-observability with useMicrosoftOpenTelemetry() from the Microsoft OpenTelemetry distro.

- Add @microsoft/opentelemetry ^0.1.0-alpha.4 dependency
- Initialize distro early in index.ts with A365 + LangChain instrumentation
- Remove ObservabilityManager/Builder/Agent365ExporterOptions from client.ts
- Update Agent-Code-Walkthrough.md

Ref: https://github.com/microsoft/opentelemetry-distro-javascript