### PR TITLE
Add w365-cua-approvers as CODEOWNERS for w365-computer-use sample

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @microsoft/agent365-approvers
+
+# W365 Computer Use sample approvers
+/dotnet/w365-computer-use/ @microsoft/w365-cua-approvers


### PR DESCRIPTION
Adds the `@microsoft/w365-cua-approvers` team as code owners (approvers) for the `/dotnet/w365-computer-use/` sample, per Alastair Fehr's guidance to prefer a team over individual aliases.

The global owner (`@microsoft/agent365-approvers`) remains unchanged.

Note: the `@microsoft/w365-cua-approvers` team must exist in the org with the desired members for the CODEOWNERS reference to take effect.