### PR TITLE
Surface Agentforce agent activity in the M365 Admin Center

### DIFF
--- a/salesforce/apex-observability/README.md
+++ b/salesforce/apex-observability/README.md
@@ -134,12 +134,30 @@ After deploying:
    printf '%s' '<your-blueprint-app-id>:<secret>' | base64 -w0
    ```
 
-3. **Assign the permission set** to the running user (REST integration user and/or Agentforce agent
-   running user):
+3. **Assign the permission set** to every identity that runs the code — the REST integration user
+   (inbound tool path) **and** the Agentforce agent's running user (origination path):
 
    ```bash
    sf org assign permset --name A365_Observability --target-org <your-org-alias>
    ```
+
+   > ⚠️ **Agentforce runs as a bot user, not you.** Once activated on a channel, the agent executes
+   > as its auto-provisioned **EinsteinServiceAgent User** (username ends in `.ext`, profile
+   > *Einstein Agent User*) — **not** the developer who tests in the Agent Builder **preview**. The
+   > preview runs as *you*, so origination works there even when the bot user is unassigned, which
+   > hides the gap. On a real turn the bot user can't see the Apex action, so Salesforce **silently
+   > drops it from the planner** and nothing is emitted (and nothing reaches the Admin Center).
+   > Assign the permission set to the bot user as well:
+   >
+   > ```bash
+   > # 1. find the Agentforce bot user (username ends in .ext)
+   > sf data query --target-org <your-org-alias> \
+   >   --query "SELECT Username FROM User WHERE Profile.Name = 'Einstein Agent User' AND IsActive = true"
+   >
+   > # 2. assign the permission set on its behalf
+   > sf org assign permset --name A365_Observability \
+   >   --on-behalf-of <bot-username-from-step-1> --target-org <your-org-alias>
+   > ```
 
 4. **(Optional) Set the callback endpoint** — only needed to exercise the outbound `A365Callout` path
    (CLIENT span). Point the `A365_Callback` Named Credential at a public HTTPS URL that forwards to your
@@ -163,6 +181,10 @@ script above). Secrets are **never** here — only in the External Credential en
 | `ServiceName__c` | `salesforce-apex` | `service.name` for boundary spans. |
 | `AgentforceServiceName__c` | `salesforce-agentforce` | `service.name` for originated (Agentforce) spans. |
 | `OriginateEnabled__c` | `false` | Enable the Agentforce origination path (see `agent/`). |
+| `RunAsUserId__c` | *(blank)* | Origination only — Entra user object id to attribute Agentforce sessions to (`user.id` → Admin Center Activity). Blank ⇒ user-less (Defender-only). See [`agent/README.md`](agent/README.md). |
+| `BlueprintId__c` | *(blank)* | Origination only — agent blueprint id (`microsoft.a365.agent.blueprint.id`). |
+| `AgentName__c` | `salesforce-agentforce` | Origination only — agent display name (`gen_ai.agent.name`); code falls back to `AgentforceServiceName__c` if cleared. |
+| `ChannelName__c` | `agentforce` | Origination only — channel name (`microsoft.channel.name`); code defaults to `agentforce` if cleared. |
 
 ## Testing
 
@@ -207,6 +229,7 @@ org-specific, so it ships as a documented **reference** — see [`agent/README.m
 | No span ingested, no error | Telemetry is fail-open — check the debug log (`sf apex tail log`) for a swallowed warning. |
 | Token hop returns `401 AADSTS7002134` | `AgentId__c` and the External Credential's blueprint Basic value are not a matched blueprint→agent pair. |
 | `You don't have read permissions on the User External Credential object` | The running user is missing the `A365_Observability` permission set (it grants `UserExternalCredential` read + the EC principal). |
+| Agentforce turns emit nothing — no `A365TelemetryQueueable` job, no session in the M365 Admin Center — **but the Agent Builder preview works** | The activated agent runs as its **bot user** (*EinsteinServiceAgent User*, username ends in `.ext`), which is missing the `A365_Observability` permission set, so Salesforce drops the Apex action from the planner for that user. The preview runs as *you* (already assigned), masking it. Assign the permset to the bot user with `--on-behalf-of` (see Deploy step 3). |
 | Ingest `403` | The token is not agent-bound (`azp` ≠ `AgentId__c`), or the tenant is not onboarded to Agent 365. |
 | Nothing emitted at all | `Enabled__c = false`, or no inbound `traceparent` (the boundary path never fabricates a trace). |
 

--- a/salesforce/apex-observability/agent/A365_Observability_Sample.agent
+++ b/salesforce/apex-observability/agent/A365_Observability_Sample.agent
@@ -41,14 +41,38 @@ start_agent Echo:
     reasoning:
         instructions: ->
             |For EVERY user message, immediately call the A365 Echo action (APEX).
-            |Pass the user's full message text as `prompt`.
-            |Pass the conversation id as `sessionId` from the RoutableId variable.
-            |Do NOT answer from general knowledge. Do NOT skip the action for greetings or small talk.
-            |Return the action's Reply text verbatim as your response.
+             Pass the user's full message text as `prompt`.
+             If a RoutableId value is available, pass it as `sessionId`; otherwise omit it.
+             Do NOT answer from general knowledge. Do NOT skip the action for greetings or small talk.
+             Return the action's Reply text verbatim as your response.
+            run @actions.APEX
         actions:
+            # `run @actions.APEX` DETERMINISTICALLY invokes the action every turn instead of leaving
+            # the decision to the planner (which may answer conversationally and skip it) — this
+            # guarantees one telemetry span per turn.
+            #
+            # NOTE: if the action is missing from the planner ENTIRELY (enabled_tools =
+            # [__end_session_action__] only, no async job, nothing emitted), the running user is
+            # almost certainly missing the A365_Observability permission set — Salesforce drops Apex
+            # actions the user can't access. On a real channel that user is the bot user, not your
+            # preview user. `run` only matters once the action is available. See agent/README.md.
+            #
+            # IMPORTANT: `run` compiles to a pre-reasoning node that carries NO bound inputs
+            # (verified in the compiled GenAiPlannerBundle graph: boundInputs={}, llmInputs=[]).
+            # So `prompt` MUST be optional (is_required: False below) — otherwise the deterministic
+            # invocation fails input validation and never fires, emitting no telemetry. With prompt
+            # optional the action fires on EVERY turn; A365AgentforceTool echoes a greeting when the
+            # prompt is blank. When the planner also reasons and calls the action via the tool node
+            # below, it fills the real message text.
+            #
+            # Inputs are left model-filled (`...`), NOT eager-bound to @variables.RoutableId
+            # (linked to @MessagingSession.Id): that variable is unresolved in the Agent Builder
+            # preview (no MessagingSession), which drops the action from the tool list. sessionId
+            # is optional; A365AgentforceTool generates a fallback trace seed when it is absent,
+            # so the action still emits a valid span in preview.
             APEX: @actions.APEX
                 with prompt = ...
-                with sessionId = @variables.RoutableId
+                with sessionId = ...
     actions:
         APEX:
             label: "APEX"
@@ -59,7 +83,7 @@ start_agent Echo:
                 prompt: string
                     label: "Prompt"
                     description: "Text sent from the Agentforce turn"
-                    is_required: True
+                    is_required: False
                     complex_data_type_name: "lightning__textType"
                 sessionId: string
                     label: "SessionId"

--- a/salesforce/apex-observability/agent/README.md
+++ b/salesforce/apex-observability/agent/README.md
@@ -31,9 +31,64 @@ Salesforce.
    assigned (this is the `default_agent_user` placeholder in the Agent Script). The running user
    also needs **Read** on `UserExternalCredential` and access to the `A365_Obs_Entra` external
    credential principal — both are granted by the permission set.
+
+   > ⚠️ **A deployed agent runs as its own bot user, not you.** Once activated on a channel the agent
+   > executes as its auto-provisioned **EinsteinServiceAgent User** (username ends in `.ext`) — a
+   > *different* identity from the developer who runs the Agent Builder **preview**. Both must hold
+   > `A365_Observability`. If only your dev user has it, the preview emits telemetry but real turns
+   > don't: Salesforce silently drops the Apex action from the planner for the unassigned bot user.
+   > Assign it to the bot user too — see [sample README](../README.md) Deploy step 3
+   > (`sf org assign permset … --on-behalf-of <bot-user>`).
 5. Activate the agent and send a message. With `OriginateEnabled__c = true` in the
    `A365_Observability_Config.Default` record, the turn originates a Salesforce-authored trace
    (`service.name = salesforce-agentforce`).
+
+> **If the action never fires, check permissions first.** When a turn's `enabled_tools`/`tools_sent`
+> contains only `__end_session_action__` (no `A365AgentforceTool`, no async job, nothing in Defender),
+> the running user is almost certainly missing the `A365_Observability` permission set — Salesforce
+> drops Apex actions the user can't access from the planner's tool list. On a real channel that user
+> is the **bot user**, not your preview user (see step 4). The directives below only matter once the
+> action is actually available to the running user.
+>
+> **Deterministic invocation (`run @actions.APEX`):** the reasoning block uses `run @actions.APEX` so
+> the action fires on **every** turn instead of leaving the choice to the planner (which may answer
+> conversationally and skip it) — guaranteeing one telemetry span per turn for the demo.
+>
+> **Why `prompt` is optional:** `run @actions.APEX` compiles to a *pre-reasoning* node that carries
+> **no bound inputs** (`boundInputs={}`, `llmInputs=[]` in the compiled `GenAiPlannerBundle` graph).
+> If `prompt` were required, that deterministic invocation would fail input validation and never fire.
+> Keeping `prompt` optional (both in the `.agent` action **and** on the `@InvocableVariable` in
+> `A365AgentforceTool`) lets `run` fire every turn — `A365AgentforceTool` echoes a greeting for a
+> blank prompt, while the planner's own tool call still fills the real message text when it reasons.
+>
+> **Agent Builder preview caveat:** the preview is not a messaging channel, so `@MessagingSession.Id`
+> (the `RoutableId` variable) is empty. Don't eager-bind `sessionId` to `@variables.RoutableId` — an
+> action referencing an unresolvable variable is dropped from the preview's tool list. Leave the
+> inputs model-filled (`with sessionId = ...`); `sessionId` is optional and `A365AgentforceTool` falls
+> back to a generated trace seed, so telemetry still flows in preview. Deploy to a real channel (or
+> type a value into the `RoutableId` field) to exercise the linked variable.
+
+## Surfacing sessions in the M365 Admin Center ("Activity" tab)
+
+An Agentforce turn has **no native Entra user** — the conversation runs inside Salesforce. By
+default the originated `invoke_agent` span is therefore *user-less*: the ingest pipeline records
+`CloudAppEvents.UserKey = 0`, so the session lands in **Defender** raw logs but never surfaces as a
+**session / Agent run-time** in the M365 Admin Center, which keys its Activity on a non-zero
+`UserKey` (resolved from the span's `user.id`).
+
+To attribute Agentforce-originated sessions to a real identity, set a **run-as Entra user** on the
+`A365_Observability_Config.Default` record (`scripts/create-obs-config.apex`):
+
+| Field | Span attribute | Maps to (CloudAppEvents) | Purpose |
+|-------|----------------|--------------------------|---------|
+| `RunAsUserId__c` | `user.id` | `UserKey` | **Attribution key** — surfaces the session/run-time in the Admin Center. Blank ⇒ user-less (Defender-only). |
+| `BlueprintId__c` | `microsoft.a365.agent.blueprint.id` | `TargetAgentBlueprintID` | The blueprint this agent instances. |
+| `AgentName__c` | `gen_ai.agent.name` | `TargetAgentName` | Agent display name (falls back to `AgentforceServiceName__c`). |
+| `ChannelName__c` | `microsoft.channel.name` | `ChannelName` | Channel (defaults to `agentforce`). |
+
+`gen_ai.conversation.id` / `microsoft.session.id` (→ `ConversationId` / `SessionIdentity`) are set
+automatically from the Agentforce session seed. All enrichment is opt-in and fail-open: leave
+`RunAsUserId__c` blank to preserve the prior user-less behavior.
 
 ## Why it's a reference, not deployable metadata
 

--- a/salesforce/apex-observability/force-app/main/default/classes/A365AgentforceTool.cls
+++ b/salesforce/apex-observability/force-app/main/default/classes/A365AgentforceTool.cls
@@ -16,7 +16,12 @@
 global with sharing class A365AgentforceTool {
 
     global class Request {
-        @InvocableVariable(label='Prompt' description='Text sent from the Agentforce turn' required=true)
+        // NOTE: `prompt` is intentionally OPTIONAL. The Echo agent invokes this action
+        // deterministically every turn via `run @actions.APEX` (a pre-reasoning node that
+        // carries no bound inputs). If `prompt` were required, that deterministic invocation
+        // would fail input validation and never fire — so no telemetry would be emitted. Left
+        // optional, the deterministic run always fires; a blank prompt is echoed as a greeting.
+        @InvocableVariable(label='Prompt' description='Text sent from the Agentforce turn (optional)')
         global String prompt;
 
         @InvocableVariable(label='SessionId' description='Agentforce conversation/session id, if the agent maps it into the action input. Used as the trace seed so every span of the conversation shares one trace.')

--- a/salesforce/apex-observability/force-app/main/default/classes/A365ObsConfig.cls
+++ b/salesforce/apex-observability/force-app/main/default/classes/A365ObsConfig.cls
@@ -20,6 +20,7 @@ public with sharing class A365ObsConfig {
     @TestVisible private static final String DEF_FMI_SCOPE = 'api://AzureADTokenExchange/.default';
     @TestVisible private static final String DEF_SERVICE_NAME = 'salesforce-apex';
     @TestVisible private static final String DEF_AF_SERVICE_NAME = 'salesforce-agentforce';
+    @TestVisible private static final String DEF_CHANNEL_NAME = 'agentforce';
 
     // Test override — when set, getInstance() returns this instead of querying CMDT
     // (CMDT rows cannot be inserted in tests, so this is how disabled/enabled is exercised).
@@ -90,6 +91,40 @@ public with sharing class A365ObsConfig {
     public static Boolean originateEnabled() {
         A365_Observability_Config__mdt c = getInstance();
         return c != null && c.OriginateEnabled__c == true;
+    }
+
+    // --- Admin Center attribution / enrichment (Option 1 + 3) --------------------
+    //
+    // Agentforce turns have no native Entra user, so an ORIGINATED invoke_agent span is
+    // user-less by default (CloudAppEvents UserKey = 0) and therefore lands only in Defender
+    // raw logs — it never surfaces as a session/run-time in the M365 Admin Center. Setting a
+    // run-as Entra user object id (below) makes Salesforce attribute the session to a real
+    // identity (user.id -> UserKey), which is what the Admin Center "Activity" tab keys on.
+    // The remaining getters enrich the session record (agent/blueprint/channel names).
+
+    // Optional Entra (AAD) user object id to attribute Agentforce-originated sessions to.
+    // Blank => omit user.id (preserves the prior user-less, Defender-only behavior).
+    public static String runAsUserId() {
+        A365_Observability_Config__mdt c = getInstance();
+        return (c != null && String.isNotBlank(c.RunAsUserId__c)) ? c.RunAsUserId__c : null;
+    }
+
+    // Optional agent blueprint id (microsoft.a365.agent.blueprint.id). Blank => omit.
+    public static String blueprintId() {
+        A365_Observability_Config__mdt c = getInstance();
+        return (c != null && String.isNotBlank(c.BlueprintId__c)) ? c.BlueprintId__c : null;
+    }
+
+    // Display name for the agent (gen_ai.agent.name); falls back to the service name.
+    public static String agentName() {
+        A365_Observability_Config__mdt c = getInstance();
+        return (c != null && String.isNotBlank(c.AgentName__c)) ? c.AgentName__c : agentforceServiceName();
+    }
+
+    // Channel name for Agentforce turns (microsoft.channel.name); defaults to 'agentforce'.
+    public static String channelName() {
+        A365_Observability_Config__mdt c = getInstance();
+        return (c != null && String.isNotBlank(c.ChannelName__c)) ? c.ChannelName__c : DEF_CHANNEL_NAME;
     }
 
     public static Boolean useS2SEndpoint() {

--- a/salesforce/apex-observability/force-app/main/default/classes/A365Telemetry.cls
+++ b/salesforce/apex-observability/force-app/main/default/classes/A365Telemetry.cls
@@ -124,10 +124,46 @@ public with sharing class A365Telemetry {
         if (!spanAttrs.containsKey('gen_ai.operation.name')) {
             spanAttrs.put('gen_ai.operation.name', 'invoke_agent');
         }
+        addAttributionAttrs(spanAttrs, seed);
         String statusCode = (ok == true) ? 'OK' : 'ERROR';
         // Root span: no parent (parentSpanId = null) — it is the top of the Agentforce trace.
         enqueueOriginated(traceId, null, rootSpanId,
             spanName, 'SERVER', statusCode, spanAttrs, startNs, endNs);
+    }
+
+    // Enrich the `invoke_agent` root with Admin Center attribution/identity attributes (Option
+    // 1 + 3). Set only when configured and not already provided by the caller:
+    //   - user.id                            -> CloudAppEvents UserKey (the attribution key the
+    //                                           Admin Center "Activity" tab surfaces sessions on).
+    //                                           Without it, UserKey = 0 and the session lands in
+    //                                           Defender raw logs only, never in the Admin Center.
+    //   - microsoft.a365.agent.blueprint.id  -> TargetAgentBlueprintID
+    //   - gen_ai.agent.name                  -> TargetAgentName
+    //   - microsoft.channel.name             -> ChannelName
+    //   - gen_ai.conversation.id / microsoft.session.id -> ConversationId / SessionIdentity
+    private static void addAttributionAttrs(Map<String, Object> spanAttrs, String seed) {
+        String runAsUser = A365ObsConfig.runAsUserId();
+        if (String.isNotBlank(runAsUser) && !spanAttrs.containsKey('user.id')) {
+            spanAttrs.put('user.id', runAsUser);
+        }
+        String blueprintId = A365ObsConfig.blueprintId();
+        if (String.isNotBlank(blueprintId) && !spanAttrs.containsKey('microsoft.a365.agent.blueprint.id')) {
+            spanAttrs.put('microsoft.a365.agent.blueprint.id', blueprintId);
+        }
+        if (!spanAttrs.containsKey('gen_ai.agent.name')) {
+            spanAttrs.put('gen_ai.agent.name', A365ObsConfig.agentName());
+        }
+        if (!spanAttrs.containsKey('microsoft.channel.name')) {
+            spanAttrs.put('microsoft.channel.name', A365ObsConfig.channelName());
+        }
+        if (String.isNotBlank(seed)) {
+            if (!spanAttrs.containsKey('gen_ai.conversation.id')) {
+                spanAttrs.put('gen_ai.conversation.id', seed);
+            }
+            if (!spanAttrs.containsKey('microsoft.session.id')) {
+                spanAttrs.put('microsoft.session.id', seed);
+            }
+        }
     }
 
     // Synthesize a default `invoke_agent` root when a tool span originates without an explicit

--- a/salesforce/apex-observability/force-app/main/default/classes/A365Telemetry.cls
+++ b/salesforce/apex-observability/force-app/main/default/classes/A365Telemetry.cls
@@ -131,9 +131,9 @@ public with sharing class A365Telemetry {
             spanName, 'SERVER', statusCode, spanAttrs, startNs, endNs);
     }
 
-    // Enrich the `invoke_agent` root with Admin Center attribution/identity attributes (Option
-    // 1 + 3). Set only when configured and not already provided by the caller:
-    //   - user.id                            -> CloudAppEvents UserKey (the attribution key the
+    // Enrich the `invoke_agent` root with Admin Center attribution/identity attributes (Option 1 + 3).
+    // `user.id` and `microsoft.a365.agent.blueprint.id` are only set when configured; the other
+    // attributes are defaulted when missing (unless already provided by the caller):
     //                                           Admin Center "Activity" tab surfaces sessions on).
     //                                           Without it, UserKey = 0 and the session lands in
     //                                           Defender raw logs only, never in the Admin Center.

--- a/salesforce/apex-observability/force-app/main/default/classes/A365Telemetry.cls
+++ b/salesforce/apex-observability/force-app/main/default/classes/A365Telemetry.cls
@@ -134,6 +134,7 @@ public with sharing class A365Telemetry {
     // Enrich the `invoke_agent` root with Admin Center attribution/identity attributes (Option 1 + 3).
     // `user.id` and `microsoft.a365.agent.blueprint.id` are only set when configured; the other
     // attributes are defaulted when missing (unless already provided by the caller):
+    //   - user.id                            -> CloudAppEvents UserKey (the attribution key the
     //                                           Admin Center "Activity" tab surfaces sessions on).
     //                                           Without it, UserKey = 0 and the session lands in
     //                                           Defender raw logs only, never in the Admin Center.

--- a/salesforce/apex-observability/force-app/main/default/classes/A365TelemetryOriginateTest.cls
+++ b/salesforce/apex-observability/force-app/main/default/classes/A365TelemetryOriginateTest.cls
@@ -40,10 +40,19 @@ private class A365TelemetryOriginateTest {
     }
 
     private static A365_Observability_Config__mdt cfg(Boolean originateEnabled) {
+        return cfg(originateEnabled, null, null);
+    }
+
+    // Overload with Admin Center attribution/enrichment fields (Option 1 + 3).
+    private static A365_Observability_Config__mdt cfg(
+        Boolean originateEnabled, String runAsUserId, String blueprintId
+    ) {
         return new A365_Observability_Config__mdt(
             Enabled__c = true,
             OriginateEnabled__c = originateEnabled,
             AgentforceServiceName__c = AF_SERVICE,
+            RunAsUserId__c = runAsUserId,
+            BlueprintId__c = blueprintId,
             TenantId__c = TENANT,
             AgentId__c = AGENT,
             IngestBase__c = 'https://agent365.svc.cloud.microsoft',
@@ -72,6 +81,19 @@ private class A365TelemetryOriginateTest {
     private static String opName(Map<String, Object> sp) {
         Map<String, Object> attrs = (Map<String, Object>) sp.get('attributes');
         return (String) attrs.get('gen_ai.operation.name');
+    }
+
+    private static Object attr(Map<String, Object> sp, String key) {
+        return ((Map<String, Object>) sp.get('attributes')).get(key);
+    }
+
+    // Returns the invoke_agent root span body from a batch of ingest bodies.
+    private static Map<String, Object> rootSpan(List<String> bodies) {
+        for (String body : bodies) {
+            Map<String, Object> sp = span(body);
+            if (opName(sp) == 'invoke_agent') { return sp; }
+        }
+        return null;
     }
 
     @IsTest
@@ -161,6 +183,58 @@ private class A365TelemetryOriginateTest {
         }
         System.assertEquals(1, invokeAgent, 'explicit root + tool span converge on one root');
         System.assertEquals(2, mock.ingestCalls, 'exactly two spans total');
+    }
+
+    @IsTest
+    static void originate_setsAttributionAttrsOnRoot_whenConfigured() {
+        String runAsUser = '33333333-3333-3333-3333-333333333333';
+        String blueprint = '44444444-4444-4444-4444-444444444444';
+        A365ObsConfig.overrideRecord = cfg(true, runAsUser, blueprint);
+        A365ObsToken.clearCache();
+        MultiMock mock = new MultiMock();
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Long t0 = 1750000000000000000L;
+        Test.startTest();
+        A365Telemetry.originateToolSpan(SEED, 'execute_tool A365AgentforceTool',
+            new Map<String, Object>{ 'gen_ai.operation.name' => 'execute_tool' }, t0, t0 + 3000000L, true);
+        Test.stopTest();
+
+        Map<String, Object> root = rootSpan(mock.ingestBodies);
+        System.assertNotEquals(null, root, 'root invoke_agent span emitted');
+        System.assertEquals(runAsUser, attr(root, 'user.id'),
+            'user.id (Admin Center UserKey) set from RunAsUserId__c');
+        System.assertEquals(blueprint, attr(root, 'microsoft.a365.agent.blueprint.id'),
+            'blueprint id enrichment set');
+        System.assertEquals(AF_SERVICE, attr(root, 'gen_ai.agent.name'),
+            'agent name falls back to the service name');
+        System.assertEquals('agentforce', attr(root, 'microsoft.channel.name'),
+            'channel name defaults to agentforce');
+        System.assertEquals(SEED, attr(root, 'gen_ai.conversation.id'),
+            'conversation id derives from the session seed');
+        System.assertEquals(SEED, attr(root, 'microsoft.session.id'),
+            'session id derives from the session seed');
+    }
+
+    @IsTest
+    static void originate_omitsUserId_whenRunAsUserBlank() {
+        A365ObsConfig.overrideRecord = cfg(true); // no run-as user configured
+        A365ObsToken.clearCache();
+        MultiMock mock = new MultiMock();
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Long t0 = 1750000000000000000L;
+        Test.startTest();
+        A365Telemetry.originateToolSpan(SEED, 'execute_tool A365AgentforceTool',
+            new Map<String, Object>{ 'gen_ai.operation.name' => 'execute_tool' }, t0, t0 + 1L, true);
+        Test.stopTest();
+
+        Map<String, Object> root = rootSpan(mock.ingestBodies);
+        System.assertNotEquals(null, root, 'root invoke_agent span still emitted');
+        System.assert(!((Map<String, Object>) root.get('attributes')).containsKey('user.id'),
+            'user.id omitted when RunAsUserId__c is blank (user-less, Defender-only)');
+        System.assert(!((Map<String, Object>) root.get('attributes')).containsKey('microsoft.a365.agent.blueprint.id'),
+            'blueprint id omitted when BlueprintId__c is blank');
     }
 
     @IsTest

--- a/salesforce/apex-observability/force-app/main/default/customMetadata/A365_Observability_Config.Default.md-meta.xml
+++ b/salesforce/apex-observability/force-app/main/default/customMetadata/A365_Observability_Config.Default.md-meta.xml
@@ -51,4 +51,26 @@
         <field>OriginateEnabled__c</field>
         <value xsi:type="xsd:boolean">false</value>
     </values>
+    <!--
+      Admin Center attribution / enrichment (Option 1 + 3). Set RunAsUserId__c to a real Entra
+      (AAD) user object id to make Agentforce-originated sessions surface in the M365 Admin
+      Center "Activity" tab (Agent run-time). Leave it blank to keep spans user-less
+      (Defender-only). The others enrich the session record and are optional.
+    -->
+    <values>
+        <field>RunAsUserId__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+    <values>
+        <field>BlueprintId__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+    <values>
+        <field>AgentName__c</field>
+        <value xsi:type="xsd:string">salesforce-agentforce</value>
+    </values>
+    <values>
+        <field>ChannelName__c</field>
+        <value xsi:type="xsd:string">agentforce</value>
+    </values>
 </CustomMetadata>

--- a/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/AgentName__c.field-meta.xml
+++ b/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/AgentName__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AgentName__c</fullName>
+    <description>Optional display name for the Agentforce agent. Emitted as the invoke_agent span attribute gen_ai.agent.name, mapped to CloudAppEvents TargetAgentName. Falls back to AgentforceServiceName__c when blank.</description>
+    <externalId>false</externalId>
+    <label>Agent Name</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/BlueprintId__c.field-meta.xml
+++ b/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/BlueprintId__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BlueprintId__c</fullName>
+    <description>Optional Agent 365 agent blueprint id. Emitted as the invoke_agent span attribute microsoft.a365.agent.blueprint.id, mapped to CloudAppEvents TargetAgentBlueprintID. Enriches the session record so the Admin Center shows the blueprint this agent is an instance of.</description>
+    <externalId>false</externalId>
+    <label>Blueprint Id</label>
+    <length>36</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/ChannelName__c.field-meta.xml
+++ b/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/ChannelName__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ChannelName__c</fullName>
+    <description>Optional channel name for Agentforce-originated turns. Emitted as the invoke_agent span attribute microsoft.channel.name, mapped to CloudAppEvents ChannelName. Falls back to 'agentforce' when blank.</description>
+    <externalId>false</externalId>
+    <label>Channel Name</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/RunAsUserId__c.field-meta.xml
+++ b/salesforce/apex-observability/force-app/main/default/objects/A365_Observability_Config__mdt/fields/RunAsUserId__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RunAsUserId__c</fullName>
+    <description>Optional Entra (AAD) user object id to attribute Agentforce-originated sessions to. Emitted as the invoke_agent span attribute user.id, which the ingest pipeline maps to CloudAppEvents UserKey — the key the M365 Admin Center uses to surface sessions/run-time. Leave blank to keep spans user-less (Defender-only, no Admin Center Activity).</description>
+    <externalId>false</externalId>
+    <label>Run As User Id</label>
+    <length>36</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/salesforce/apex-observability/scripts/create-obs-config.apex
+++ b/salesforce/apex-observability/scripts/create-obs-config.apex
@@ -8,6 +8,11 @@
 //   <<TENANT_ID>>  — your Entra tenant id
 //   <<AGENT_ID>>   — the Agent 365 agent id (the agentId in the ingest URL; token azp must match)
 //
+// Optional (Admin Center attribution / enrichment, Option 1 + 3) — fill in the map below:
+//   RunAsUserId__c — Entra user object id to attribute Agentforce sessions to, so they surface
+//                    in the M365 Admin Center "Activity" tab. Blank => user-less (Defender-only).
+//   BlueprintId__c — agent blueprint id for session enrichment.
+//
 // Run:
 //   sf apex run --file scripts/create-obs-config.apex --target-org <<ORG_ALIAS>>
 //
@@ -28,7 +33,14 @@ Map<String, Object> vals = new Map<String, Object>{
     // Origination (Agentforce-native) fields — set OriginateEnabled__c = true only if you
     // build the optional Agentforce agent (see ../agent/README.md).
     'AgentforceServiceName__c' => 'salesforce-agentforce',
-    'OriginateEnabled__c' => false
+    'OriginateEnabled__c' => false,
+    // Admin Center attribution / enrichment (Option 1 + 3). Set RunAsUserId__c to a real Entra
+    // (AAD) user object id so Agentforce sessions surface as run-time in the M365 Admin Center
+    // "Activity" tab; leave blank to keep spans user-less (Defender-only). Others are optional.
+    'RunAsUserId__c' => '',
+    'BlueprintId__c' => '',
+    'AgentName__c' => 'salesforce-agentforce',
+    'ChannelName__c' => 'agentforce'
 };
 for (String f : vals.keySet()) {
     Metadata.CustomMetadataValue v = new Metadata.CustomMetadataValue();


### PR DESCRIPTION
Agentforce turns originate an Agent 365 trace (an invoke_agent root + an execute_tool span) from Salesforce via the A365AgentforceTool Apex action. Two things are needed for those sessions to appear in the M365 Admin Center "Activity" tab, and this change delivers both.

1) Attribution (so the session is not user-less). An Agentforce turn has no
   native Entra user, so the originated invoke_agent span was emitted user-less
   (CloudAppEvents UserKey = 0) and landed only in Defender raw logs, never as a
   session/run-time in the Admin Center (which keys on a non-zero UserKey from
   user.id). New opt-in, fail-open CMDT fields enrich the root span:
   RunAsUserId__c -> user.id (the attribution key), BlueprintId__c ->
   microsoft.a365.agent.blueprint.id, AgentName__c -> gen_ai.agent.name,
   ChannelName__c -> microsoft.channel.name. Implemented in
   A365Telemetry.addAttributionAttrs with A365ObsConfig getters; blank by
   default preserves the prior user-less (Defender-only) behavior. Tests cover
   the attribution-set and user-less-default paths. Dry-run RunLocalTests: 44
   passing.

2) The permission gate that lets the action run at all. A deployed Agentforce
   agent executes as its auto-provisioned bot user (EinsteinServiceAgent User,
   ".ext" username), NOT the developer who tests in the Agent Builder preview.
   Without the A365_Observability permission set on that bot user, Salesforce
   silently drops the Apex action from the planner's tool list and the turn
   emits no telemetry. The preview runs as the developer (already assigned),
   masking the gap. Documented the "--on-behalf-of" bot-user assignment, a query
   to find the bot user, and a troubleshooting row for the exact symptom.

The org-specific reference agent (agent/) invokes the action deterministically via "run @actions.APEX" (with prompt optional, since the compiled pre-reasoning node carries no bound inputs) so a span is emitted every turn, and leaves inputs model-filled rather than eager-bound to @variables.RoutableId so the action is not dropped in the preview. These are documented as reliability niceties; the actual origination gate is the bot-user permission set above.