### PR TITLE
Add W365 screenshare to w365-computer-use sample

### DIFF
--- a/dotnet/w365-computer-use/sample-agent/Agent/MyAgent.cs
+++ b/dotnet/w365-computer-use/sample-agent/Agent/MyAgent.cs
@@ -145,9 +145,8 @@ public class MyAgent : AgentApplication
         AgenticAuthHandlerName = configuration.GetValue<string>("AgentApplication:AgenticAuthHandlerName");
         W365AuthHandlerName = configuration.GetValue<string>("AgentApplication:W365AuthHandlerName");
 
-        // ARI (screenshare) agentic handler. Defaults to "ari" but is only wired in when a matching
-        // handler section exists — otherwise the agent is never signed in for ARI and
-        // GetTurnTokenAsync("ari") returns empty, so no screenshare link is emitted.
+        // ARI (screenshare) agentic handler. Only wired in when a matching handler section exists;
+        // otherwise it stays null and no screenshare link is emitted.
         var ariHandlerName = configuration.GetValue<string>("AgentApplication:ScreenShareAuthHandlerName") ?? "ari";
         ScreenShareAuthHandlerName =
             configuration.GetSection($"AgentApplication:UserAuthorization:Handlers:{ariHandlerName}").Exists()
@@ -256,10 +255,9 @@ public class MyAgent : AgentApplication
                     var localSessionKey = BuildLocalSessionKey(conversationId, fromAccount);
 
                     // Fast path: the user is asking for a (fresh) screen share link. The link is
-                    // otherwise emitted only once when a session starts, and each handoff record is
-                    // single-use + short-lived (5 min) and lost on agent restart — so without this
-                    // there is no recovery path. Handled deterministically here (before the LLM
-                    // classifier) because the model has no tool for it and would otherwise refuse.
+                    // otherwise emitted only once when a session starts, and each handoff is
+                    // single-use and short-lived — so handle re-mint requests here, before the LLM
+                    // classifier (the model has no tool for it and would otherwise refuse).
                     if (IsScreenShareLinkRequest(userText))
                     {
                         string reply;
@@ -521,10 +519,8 @@ public class MyAgent : AgentApplication
     }
 
     /// <summary>
-    /// True when the user is asking for a (fresh) screen-share link for the current session.
-    /// Deterministic keyword match — requires an explicit "screen share" / "screenshare" mention
-    /// plus an intent word (link / again / new / resend / …) so it doesn't swallow normal desktop
-    /// tasks. Used to short-circuit the LLM classifier and re-mint the link directly.
+    /// True when the user is asking for a (fresh) screen-share link. Requires an explicit
+    /// "screen share" mention plus an intent word so it doesn't swallow normal desktop tasks.
     /// </summary>
     private static bool IsScreenShareLinkRequest(string text)
     {
@@ -548,12 +544,10 @@ public class MyAgent : AgentApplication
     }
 
     /// <summary>
-    /// Mint the ARI bearer token in-turn (the only place we have a <see cref="ITurnContext"/>),
-    /// persist a one-time <see cref="HandoffRecord"/> keyed by <paramref name="sessionId"/>, and
-    /// return the chat link the user clicks — which carries only an opaque <c>sid</c>+<c>hc</c>,
-    /// never the token. Returns <c>null</c> (and skips link emission) when
-    /// <c>ScreenShare:PageBaseUrl</c> is unconfigured or <paramref name="screenShareUrl"/> is
-    /// missing.
+    /// Mints the ARI bearer token in-turn, stores a one-time <see cref="HandoffRecord"/> keyed by
+    /// <paramref name="sessionId"/>, and returns the chat link (which carries only an opaque
+    /// <c>sid</c>+<c>hc</c>, never the token). Returns <c>null</c> when <c>ScreenShare:PageBaseUrl</c>
+    /// is unconfigured or no token/URL is available.
     /// </summary>
     private async Task<string?> BuildScreenSharePageUrlAsync(ITurnContext turnContext, string sessionId, string screenShareUrl)
     {
@@ -564,8 +558,7 @@ public class MyAgent : AgentApplication
         }
 
         // PageBaseUrl precedence: explicit config > WEBSITE_HOSTNAME (Azure App Service
-        // auto-populates this) > null (skip). The App Service fallback means prod deployments
-        // don't have to hard-code their URL in appsettings.json.
+        // auto-populates this) > null (skip).
         var pageBaseUrl = _screenShareOptions.PageBaseUrl;
         if (string.IsNullOrWhiteSpace(pageBaseUrl) || pageBaseUrl.Contains("<<", StringComparison.Ordinal))
         {
@@ -578,15 +571,12 @@ public class MyAgent : AgentApplication
             return null;
         }
 
-        // 1. Mint the ARI bearer token. Env override mirrors the existing BEARER_TOKEN dev pattern
-        //    and lets devs validate the end-to-end flow with a supplied token before the agentic
-        //    token plumbing is ready.
+        // 1. Mint the ARI bearer token. The ARI_BEARER_TOKEN env override mirrors the existing
+        //    BEARER_TOKEN dev pattern for local testing.
         var ariToken = Environment.GetEnvironmentVariable("ARI_BEARER_TOKEN");
         if (string.IsNullOrEmpty(ariToken))
         {
-            // No ARI handler section is configured (ScreenShareAuthHandlerName is null) and no
-            // explicit token override — nothing to mint. Skip quietly instead of calling
-            // GetTurnTokenAsync with a guessed handler name and logging a warning every session.
+            // No ARI handler configured and no token override — nothing to mint.
             if (string.IsNullOrEmpty(ScreenShareAuthHandlerName))
             {
                 _logger.LogDebug("No ARI auth handler configured and ARI_BEARER_TOKEN not set — skipping screenshare link");
@@ -609,15 +599,13 @@ public class MyAgent : AgentApplication
             return null;
         }
 
-        // 2. Parse JWT exp — do NOT guess lifetime. -5 min keeps the SDK off the expiry boundary
-        //    (it raises TOKEN_EXPIRED slightly before exp).
+        // 2. Parse the JWT expiry; -5 min keeps the SDK off the expiry boundary.
         DateTime safeExp;
         try
         {
             var parsed = new JwtSecurityTokenHandler().ReadJwtToken(ariToken);
-            // ReadJwtToken succeeds even when the token has no (or an unparsable) exp claim, in which
-            // case ValidTo defaults to DateTime.MinValue. Require a usable, still-valid expiry rather
-            // than emitting a link whose token is already (or effectively) expired.
+            // ValidTo is DateTime.MinValue when the token has no/unparsable exp claim — require a
+            // usable, still-valid expiry rather than emitting an already-expired link.
             if (parsed.ValidTo == DateTime.MinValue || parsed.ValidTo <= DateTime.UtcNow)
             {
                 _logger.LogWarning("ARI token has no usable expiry (ValidTo={ValidTo:o}) — skipping screenshare link", parsed.ValidTo);
@@ -631,8 +619,8 @@ public class MyAgent : AgentApplication
             return null;
         }
 
-        // 3. Generate one-time handoff code (256 bits, URL-safe base64). The raw value travels in
-        //    the chat link and is matched in constant time against the SHA-256 hash kept server-side.
+        // 3. Generate a one-time handoff code (256-bit). The raw value travels in the chat link;
+        //    only its SHA-256 hash is kept server-side.
         var rawHc = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
         var hcHash = SHA256.HashData(Encoding.UTF8.GetBytes(rawHc));
 
@@ -644,8 +632,7 @@ public class MyAgent : AgentApplication
             return null;
         }
 
-        // 5. Persist record. 5-minute HC TTL; the background sweeper in HandoffStore removes burned
-        //    and expired records.
+        // 5. Persist the record with a 5-minute handoff TTL.
         _handoffStore.Set(sessionId, new HandoffRecord
         {
             ScreenShareUrl = screenShareUrl,
@@ -656,7 +643,7 @@ public class MyAgent : AgentApplication
             AriTokenExpiresAtUtc = safeExp
         });
 
-        // 6. Build the link — sid + hc only. NO token, NO screenShareUrl in the URL.
+        // 6. Build the link — sid + hc only, never the token or the screenShareUrl.
         var baseUrl = pageBaseUrl!.TrimEnd('/');
         var qs = $"sid={Uri.EscapeDataString(sessionId)}&hc={Uri.EscapeDataString(rawHc)}";
         return $"{baseUrl}/screenshare.html?{qs}";

--- a/dotnet/w365-computer-use/sample-agent/Agent/MyAgent.cs
+++ b/dotnet/w365-computer-use/sample-agent/Agent/MyAgent.cs
@@ -582,22 +582,30 @@ public class MyAgent : AgentApplication
         //    and lets devs validate the end-to-end flow with a supplied token before the agentic
         //    token plumbing is ready.
         var ariToken = Environment.GetEnvironmentVariable("ARI_BEARER_TOKEN");
-        var ariHandlerName = ScreenShareAuthHandlerName ?? "ari";
         if (string.IsNullOrEmpty(ariToken))
         {
+            // No ARI handler section is configured (ScreenShareAuthHandlerName is null) and no
+            // explicit token override — nothing to mint. Skip quietly instead of calling
+            // GetTurnTokenAsync with a guessed handler name and logging a warning every session.
+            if (string.IsNullOrEmpty(ScreenShareAuthHandlerName))
+            {
+                _logger.LogDebug("No ARI auth handler configured and ARI_BEARER_TOKEN not set — skipping screenshare link");
+                return null;
+            }
+
             try
             {
-                ariToken = await UserAuthorization.GetTurnTokenAsync(turnContext, ariHandlerName).ConfigureAwait(false);
+                ariToken = await UserAuthorization.GetTurnTokenAsync(turnContext, ScreenShareAuthHandlerName).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to acquire ARI token via UserAuthorization '{Handler}' handler — skipping screenshare link", ariHandlerName);
+                _logger.LogWarning(ex, "Failed to acquire ARI token via UserAuthorization '{Handler}' handler — skipping screenshare link", ScreenShareAuthHandlerName);
                 return null;
             }
         }
         if (string.IsNullOrEmpty(ariToken))
         {
-            _logger.LogWarning("ARI token not available (GetTurnTokenAsync '{Handler}' returned empty) — skipping screenshare link", ariHandlerName);
+            _logger.LogWarning("ARI token not available (GetTurnTokenAsync '{Handler}' returned empty) — skipping screenshare link", ScreenShareAuthHandlerName ?? "ari");
             return null;
         }
 
@@ -607,6 +615,14 @@ public class MyAgent : AgentApplication
         try
         {
             var parsed = new JwtSecurityTokenHandler().ReadJwtToken(ariToken);
+            // ReadJwtToken succeeds even when the token has no (or an unparsable) exp claim, in which
+            // case ValidTo defaults to DateTime.MinValue. Require a usable, still-valid expiry rather
+            // than emitting a link whose token is already (or effectively) expired.
+            if (parsed.ValidTo == DateTime.MinValue || parsed.ValidTo <= DateTime.UtcNow)
+            {
+                _logger.LogWarning("ARI token has no usable expiry (ValidTo={ValidTo:o}) — skipping screenshare link", parsed.ValidTo);
+                return null;
+            }
             safeExp = parsed.ValidTo.AddMinutes(-5);
         }
         catch (Exception ex)

--- a/dotnet/w365-computer-use/sample-agent/Agent/MyAgent.cs
+++ b/dotnet/w365-computer-use/sample-agent/Agent/MyAgent.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
 using W365ComputerUseSample.ComputerUse;
+using W365ComputerUseSample.ScreenShare;
 using W365ComputerUseSample.Telemetry;
 using Microsoft.Agents.A365.Observability.Caching;
 using Microsoft.Agents.A365.Runtime.Utils;
@@ -12,7 +16,9 @@ using Microsoft.Agents.Builder.App;
 using Microsoft.Agents.Builder.State;
 using Microsoft.Agents.Core;
 using Microsoft.Agents.Core.Models;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Client;
 
 namespace W365ComputerUseSample.Agent;
@@ -28,6 +34,8 @@ public class MyAgent : AgentApplication
     private readonly IMcpToolRegistrationService _toolService;
     private readonly ComputerUseOrchestrator _orchestrator;
     private readonly string[] _mcpServerUrls;
+    private readonly ScreenShareOptions _screenShareOptions;
+    private readonly HandoffStore _handoffStore;
 
     /// <summary>
     /// Subset of <see cref="_mcpServerUrls"/> whose path names the W365 Computer-Use server.
@@ -45,6 +53,13 @@ public class MyAgent : AgentApplication
 
     private readonly string? AgenticAuthHandlerName;
     private readonly string? W365AuthHandlerName;
+
+    /// <summary>
+    /// ARI (screenshare) agentic handler. Defaults to "ari" but is only wired in when a matching
+    /// handler is configured under AgentApplication:UserAuthorization:Handlers — otherwise it stays
+    /// null and screenshare link emission is skipped (no ARI token available).
+    /// </summary>
+    private readonly string? ScreenShareAuthHandlerName;
 
     /// <summary>
     /// Check if a bearer token is available in the environment for development/testing.
@@ -99,12 +114,16 @@ public class MyAgent : AgentApplication
         IExporterTokenCache<AgenticTokenStruct> agentTokenCache,
         IMcpToolRegistrationService toolService,
         ComputerUseOrchestrator orchestrator,
+        IOptions<ScreenShareOptions> screenShareOptions,
+        HandoffStore handoffStore,
         ILogger<MyAgent> logger) : base(options)
     {
         _agentTokenCache = agentTokenCache;
         _logger = logger;
         _toolService = toolService;
         _orchestrator = orchestrator;
+        _screenShareOptions = screenShareOptions.Value;
+        _handoffStore = handoffStore;
 
         // Support multiple MCP server URLs; fall back to single McpServer:Url for backward compat
         _mcpServerUrls = configuration.GetSection("McpServers").Get<string[]>() ?? [];
@@ -126,11 +145,20 @@ public class MyAgent : AgentApplication
         AgenticAuthHandlerName = configuration.GetValue<string>("AgentApplication:AgenticAuthHandlerName");
         W365AuthHandlerName = configuration.GetValue<string>("AgentApplication:W365AuthHandlerName");
 
+        // ARI (screenshare) agentic handler. Defaults to "ari" but is only wired in when a matching
+        // handler section exists — otherwise the agent is never signed in for ARI and
+        // GetTurnTokenAsync("ari") returns empty, so no screenshare link is emitted.
+        var ariHandlerName = configuration.GetValue<string>("AgentApplication:ScreenShareAuthHandlerName") ?? "ari";
+        ScreenShareAuthHandlerName =
+            configuration.GetSection($"AgentApplication:UserAuthorization:Handlers:{ariHandlerName}").Exists()
+                ? ariHandlerName
+                : null;
+
         // Greet when members are added
         OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeMessageAsync);
 
         // Compute auth handler arrays once
-        var agenticHandlers = new[] { AgenticAuthHandlerName, W365AuthHandlerName }
+        var agenticHandlers = new[] { AgenticAuthHandlerName, W365AuthHandlerName, ScreenShareAuthHandlerName }
             .OfType<string>()
             .Where(handler => !string.IsNullOrEmpty(handler))
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -227,6 +255,33 @@ public class MyAgent : AgentApplication
                     var conversationId = turnContext.Activity.Conversation?.Id ?? Guid.NewGuid().ToString();
                     var localSessionKey = BuildLocalSessionKey(conversationId, fromAccount);
 
+                    // Fast path: the user is asking for a (fresh) screen share link. The link is
+                    // otherwise emitted only once when a session starts, and each handoff record is
+                    // single-use + short-lived (5 min) and lost on agent restart — so without this
+                    // there is no recovery path. Handled deterministically here (before the LLM
+                    // classifier) because the model has no tool for it and would otherwise refuse.
+                    if (IsScreenShareLinkRequest(userText))
+                    {
+                        string reply;
+                        var (ssFound, ssSessionId, ssUrl) = await _orchestrator
+                            .TryGetActiveScreenShareAsync(localSessionKey, cancellationToken)
+                            .ConfigureAwait(false);
+                        if (ssFound)
+                        {
+                            var freshLink = await BuildScreenSharePageUrlAsync(turnContext, ssSessionId, ssUrl)
+                                .ConfigureAwait(false);
+                            reply = freshLink != null
+                                ? $"🖥️ Watch this session live: [Open screen share]({freshLink})"
+                                : "I couldn't generate a screen share link right now. Please try again in a moment.";
+                        }
+                        else
+                        {
+                            reply = "There's no active Windows 365 session yet. Ask me to do something on the desktop first, then I can share a live link.";
+                        }
+                        turnContext.StreamingResponse.QueueTextChunk(reply);
+                        return;
+                    }
+
                     // Step 1: classify intent with a cheap tool-less LLM call. If the message
                     // doesn't need desktop control ("hi", "summarize my inbox", etc.) we skip
                     // W365 tool loading and explicit session startup entirely.
@@ -236,7 +291,7 @@ public class MyAgent : AgentApplication
                     {
                         // Non-CUA fast path: with the current CUA-only ToolingManifest, skip MCP
                         // discovery entirely so chit-chat never touches W365.
-                        var (_, nonCuaAdditionalTools, _, _) = await GetToolsAsync(turnContext, ToolAuthHandlerName, includeW365: false, localSessionKey, cancellationToken);
+                        var (_, nonCuaAdditionalTools, _, _, _) = await GetToolsAsync(turnContext, ToolAuthHandlerName, includeW365: false, localSessionKey, cancellationToken);
                         var directResponse = await _orchestrator.RunAsync(
                             localSessionKey,
                             userText,
@@ -270,7 +325,7 @@ public class MyAgent : AgentApplication
                     }
 
                     // Get MCP tools — direct connection in Dev, SDK in Production
-                    var (w365Tools, additionalTools, mcpClient, prestartedW365SessionId) = await GetToolsAsync(turnContext, ToolAuthHandlerName, includeW365: true, localSessionKey, cancellationToken);
+                    var (w365Tools, additionalTools, mcpClient, prestartedW365SessionId, prestartedScreenShareUrl) = await GetToolsAsync(turnContext, ToolAuthHandlerName, includeW365: true, localSessionKey, cancellationToken);
 
                     try
                     {
@@ -319,7 +374,19 @@ public class MyAgent : AgentApplication
                             },
                             onFolderLinkReady: async url => await turnContext.SendActivityAsync(
                                 MessageFactory.Text($"📸 Screenshots for this session: [View folder]({url})"), cancellationToken),
+                            onScreenShareLinkReady: async (sessionId, screenShareUrl) =>
+                            {
+                                var link = await BuildScreenSharePageUrlAsync(turnContext, sessionId, screenShareUrl)
+                                    .ConfigureAwait(false);
+                                if (link != null)
+                                {
+                                    await turnContext.SendActivityAsync(
+                                        MessageFactory.Text($"🖥️ Watch this session live: [Open screen share]({link})"),
+                                        cancellationToken);
+                                }
+                            },
                             prestartedW365SessionId: prestartedW365SessionId,
+                            prestartedScreenShareUrl: prestartedScreenShareUrl,
                             cancellationToken: cancellationToken);
 
                         // Send the response
@@ -346,7 +413,7 @@ public class MyAgent : AgentApplication
     /// When <paramref name="includeW365"/> is <c>false</c>, the W365 server(s) are skipped —
     /// used on the non-CUA fast path so chit-chat never starts a Cloud PC session.
     /// </summary>
-    private async Task<(IList<AITool>? W365Tools, IList<AITool>? AdditionalTools, IMcpClient? Client, string? PrestartedW365SessionId)> GetToolsAsync(
+    private async Task<(IList<AITool>? W365Tools, IList<AITool>? AdditionalTools, IMcpClient? Client, string? PrestartedW365SessionId, string? PrestartedScreenShareUrl)> GetToolsAsync(
         ITurnContext context,
         string? authHandlerName,
         bool includeW365,
@@ -382,7 +449,7 @@ public class MyAgent : AgentApplication
         if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(agentId))
         {
             _logger.LogWarning("No auth token or agent identity available. Cannot connect to MCP.");
-            return (null, null, null, null);
+            return (null, null, null, null, null);
         }
 
         try
@@ -421,23 +488,23 @@ public class MyAgent : AgentApplication
                         existingSessionId,
                         cancellationToken);
                     var additionalToolsForCua = Array.Empty<AITool>();
-                    return (w365Result.Tools, additionalToolsForCua, w365Result.Client, w365Result.SessionId);
+                    return (w365Result.Tools, additionalToolsForCua, w365Result.Client, w365Result.SessionId, w365Result.ScreenShareUrl);
                 }
 
                 _logger.LogInformation("Skipping production MCP tool discovery for non-CUA turn while ToolingManifest is restricted to W365 CUA.");
-                return (null, Array.Empty<AITool>(), null, null);
+                return (null, Array.Empty<AITool>(), null, null, null);
             }
 
             var w365Tools = includeW365 ? FilterW365Tools(allTools) : null;
             var additionalTools = FilterAdditionalTools(allTools);
-            return (w365Tools, additionalTools, mcpClient, null);
+            return (w365Tools, additionalTools, mcpClient, null, null);
         }
         catch (Exception ex)
         {
             if (ShouldSkipToolingOnErrors())
             {
                 _logger.LogWarning(ex, "Failed to connect to MCP servers. Continuing without tools (SKIP_TOOLING_ON_ERRORS=true).");
-                return (null, null, null, null);
+                return (null, null, null, null, null);
             }
 
             _logger.LogError(ex, "Failed to connect to MCP servers.");
@@ -451,6 +518,132 @@ public class MyAgent : AgentApplication
                ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
                ?? "Production";
         return env.Equals("Development", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// True when the user is asking for a (fresh) screen-share link for the current session.
+    /// Deterministic keyword match — requires an explicit "screen share" / "screenshare" mention
+    /// plus an intent word (link / again / new / resend / …) so it doesn't swallow normal desktop
+    /// tasks. Used to short-circuit the LLM classifier and re-mint the link directly.
+    /// </summary>
+    private static bool IsScreenShareLinkRequest(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var t = text.ToLowerInvariant();
+
+        var mentionsScreenShare = t.Contains("screen share")
+            || t.Contains("screenshare")
+            || t.Contains("screen-share");
+        if (!mentionsScreenShare) return false;
+
+        return t.Contains("link")
+            || t.Contains("again")
+            || t.Contains("new")
+            || t.Contains("another")
+            || t.Contains("fresh")
+            || t.Contains("resend")
+            || t.Contains("re-send")
+            || t.Contains("regenerate")
+            || t.Contains("watch");
+    }
+
+    /// <summary>
+    /// Mint the ARI bearer token in-turn (the only place we have a <see cref="ITurnContext"/>),
+    /// persist a one-time <see cref="HandoffRecord"/> keyed by <paramref name="sessionId"/>, and
+    /// return the chat link the user clicks — which carries only an opaque <c>sid</c>+<c>hc</c>,
+    /// never the token. Returns <c>null</c> (and skips link emission) when
+    /// <c>ScreenShare:PageBaseUrl</c> is unconfigured or <paramref name="screenShareUrl"/> is
+    /// missing.
+    /// </summary>
+    private async Task<string?> BuildScreenSharePageUrlAsync(ITurnContext turnContext, string sessionId, string screenShareUrl)
+    {
+        if (string.IsNullOrWhiteSpace(screenShareUrl))
+        {
+            _logger.LogDebug("No screenShareUrl on platform response — skipping screenshare link emission");
+            return null;
+        }
+
+        // PageBaseUrl precedence: explicit config > WEBSITE_HOSTNAME (Azure App Service
+        // auto-populates this) > null (skip). The App Service fallback means prod deployments
+        // don't have to hard-code their URL in appsettings.json.
+        var pageBaseUrl = _screenShareOptions.PageBaseUrl;
+        if (string.IsNullOrWhiteSpace(pageBaseUrl) || pageBaseUrl.Contains("<<", StringComparison.Ordinal))
+        {
+            var hostname = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME");
+            pageBaseUrl = string.IsNullOrWhiteSpace(hostname) ? null : $"https://{hostname}";
+        }
+        if (string.IsNullOrWhiteSpace(pageBaseUrl))
+        {
+            _logger.LogWarning("ScreenShare:PageBaseUrl not configured and WEBSITE_HOSTNAME not set — skipping screenshare link emission");
+            return null;
+        }
+
+        // 1. Mint the ARI bearer token. Env override mirrors the existing BEARER_TOKEN dev pattern
+        //    and lets devs validate the end-to-end flow with a supplied token before the agentic
+        //    token plumbing is ready.
+        var ariToken = Environment.GetEnvironmentVariable("ARI_BEARER_TOKEN");
+        var ariHandlerName = ScreenShareAuthHandlerName ?? "ari";
+        if (string.IsNullOrEmpty(ariToken))
+        {
+            try
+            {
+                ariToken = await UserAuthorization.GetTurnTokenAsync(turnContext, ariHandlerName).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to acquire ARI token via UserAuthorization '{Handler}' handler — skipping screenshare link", ariHandlerName);
+                return null;
+            }
+        }
+        if (string.IsNullOrEmpty(ariToken))
+        {
+            _logger.LogWarning("ARI token not available (GetTurnTokenAsync '{Handler}' returned empty) — skipping screenshare link", ariHandlerName);
+            return null;
+        }
+
+        // 2. Parse JWT exp — do NOT guess lifetime. -5 min keeps the SDK off the expiry boundary
+        //    (it raises TOKEN_EXPIRED slightly before exp).
+        DateTime safeExp;
+        try
+        {
+            var parsed = new JwtSecurityTokenHandler().ReadJwtToken(ariToken);
+            safeExp = parsed.ValidTo.AddMinutes(-5);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse ARI token JWT — skipping screenshare link");
+            return null;
+        }
+
+        // 3. Generate one-time handoff code (256 bits, URL-safe base64). The raw value travels in
+        //    the chat link and is matched in constant time against the SHA-256 hash kept server-side.
+        var rawHc = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+        var hcHash = SHA256.HashData(Encoding.UTF8.GetBytes(rawHc));
+
+        // 4. Capture owner identity (fail-closed: oid must be present).
+        var ownerOid = turnContext.Activity.From?.AadObjectId;
+        if (string.IsNullOrEmpty(ownerOid))
+        {
+            _logger.LogWarning("Activity.From.AadObjectId is missing — cannot bind screenshare link to a user; skipping");
+            return null;
+        }
+
+        // 5. Persist record. 5-minute HC TTL; the background sweeper in HandoffStore removes burned
+        //    and expired records.
+        _handoffStore.Set(sessionId, new HandoffRecord
+        {
+            ScreenShareUrl = screenShareUrl,
+            OwnerAadObjectId = ownerOid,
+            HandoffCodeHash = hcHash,
+            HandoffExpiresAtUtc = DateTime.UtcNow.AddMinutes(5),
+            AriToken = ariToken,
+            AriTokenExpiresAtUtc = safeExp
+        });
+
+        // 6. Build the link — sid + hc only. NO token, NO screenShareUrl in the URL.
+        var baseUrl = pageBaseUrl!.TrimEnd('/');
+        var qs = $"sid={Uri.EscapeDataString(sessionId)}&hc={Uri.EscapeDataString(rawHc)}";
+        return $"{baseUrl}/screenshare.html?{qs}";
     }
 
     private IList<AITool>? FilterW365Tools(IList<AITool>? allTools)

--- a/dotnet/w365-computer-use/sample-agent/ComputerUse/ComputerUseOrchestrator.cs
+++ b/dotnet/w365-computer-use/sample-agent/ComputerUse/ComputerUseOrchestrator.cs
@@ -417,8 +417,10 @@ public class ComputerUseOrchestrator
         Func<string, Task>? onStatusUpdate = null,
         Func<bool, Task>? onCuaStarting = null,
         Func<string, Task>? onFolderLinkReady = null,
+        Func<string, string, Task>? onScreenShareLinkReady = null,
         bool includeCuaTool = true,
         string? prestartedW365SessionId = null,
+        string? prestartedScreenShareUrl = null,
         CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Processing message for conversation {ConversationId}: {Message}", conversationId, Truncate(userMessage, 100));
@@ -451,8 +453,10 @@ public class ComputerUseOrchestrator
                 onStatusUpdate,
                 onCuaStarting,
                 onFolderLinkReady,
+                onScreenShareLinkReady,
                 includeCuaTool,
                 prestartedW365SessionId,
+                prestartedScreenShareUrl,
                 cancellationToken);
         }
         finally
@@ -472,8 +476,10 @@ public class ComputerUseOrchestrator
         Func<string, Task>? onStatusUpdate,
         Func<bool, Task>? onCuaStarting,
         Func<string, Task>? onFolderLinkReady,
+        Func<string, string, Task>? onScreenShareLinkReady,
         bool includeCuaTool,
         string? prestartedW365SessionId,
+        string? prestartedScreenShareUrl,
         CancellationToken cancellationToken)
     {
         if (session.SessionStarted)
@@ -481,10 +487,32 @@ public class ComputerUseOrchestrator
             _logger.LogInformation("Reusing session for conversation {ConversationId}, W365SessionId={SessionId}", conversationId, session.W365SessionId);
         }
 
+        // One-time emission of the browser handoff link once a W365 session (with a
+        // screenShareUrl) is available. Mirrors the onFolderLinkReady pattern.
+        async Task EmitScreenShareLinkIfReadyAsync()
+        {
+            if (onScreenShareLinkReady == null || session.ScreenShareLinkEmitted) return;
+            var sid = session.W365SessionId;
+            if (string.IsNullOrWhiteSpace(sid)) return;
+            if (!session.ScreenShareUrlsBySessionId.TryGetValue(sid, out var url)
+                || string.IsNullOrWhiteSpace(url)) return;
+            session.ScreenShareLinkEmitted = true;
+            await onScreenShareLinkReady(sid, url);
+        }
+
         if (includeCuaTool && !string.IsNullOrWhiteSpace(prestartedW365SessionId) && string.IsNullOrEmpty(session.W365SessionId))
         {
             session.TrackAndSelectSession(prestartedW365SessionId);
+            if (!string.IsNullOrWhiteSpace(prestartedScreenShareUrl))
+            {
+                session.ScreenShareUrlsBySessionId[prestartedW365SessionId] = prestartedScreenShareUrl;
+            }
             _logger.LogInformation("Using prestarted W365 session {SessionId} for conversation {ConversationId}", prestartedW365SessionId, conversationId);
+        }
+
+        if (includeCuaTool)
+        {
+            await EmitScreenShareLinkIfReadyAsync();
         }
 
         if (includeCuaTool && TryExtractSessionId(userMessage, out var requestedSessionId))
@@ -700,6 +728,7 @@ public class ComputerUseOrchestrator
                                 }
                                 await StartW365SessionAsync(session, w365Tools, additionalTools, mcpClient, cancellationToken);
                                 _logger.LogInformation("Session marked started for conversation {ConversationId}", conversationId);
+                                await EmitScreenShareLinkIfReadyAsync();
                             }
                             else if (onCuaStarting != null)
                             {
@@ -900,6 +929,11 @@ public class ComputerUseOrchestrator
         }
 
         session.TrackAndSelectSession(sessionId);
+        if (TryExtractStringProperty(resultStr, "screenShareUrl", out var screenShareUrl)
+            && !string.IsNullOrWhiteSpace(screenShareUrl))
+        {
+            session.ScreenShareUrlsBySessionId[sessionId] = screenShareUrl;
+        }
         _logger.LogInformation("Started explicit W365 session {SessionId}", sessionId);
     }
 
@@ -1092,6 +1126,82 @@ public class ComputerUseOrchestrator
             && _sessions.TryGetValue(conversationId, out var session)
             ? session.W365SessionId
             : null;
+    }
+
+    /// <summary>
+    /// Returns the cached screenShareUrl for the conversation's active W365 session, if one was
+    /// captured at start time. Does not perform any network calls.
+    /// </summary>
+    public bool TryGetActiveScreenShare(string conversationId, out string sessionId, out string screenShareUrl)
+    {
+        sessionId = string.Empty;
+        screenShareUrl = string.Empty;
+        if (string.IsNullOrWhiteSpace(conversationId)) return false;
+        if (!_sessions.TryGetValue(conversationId, out var session)) return false;
+
+        var sid = session.W365SessionId;
+        if (string.IsNullOrWhiteSpace(sid)) return false;
+        if (!session.ScreenShareUrlsBySessionId.TryGetValue(sid, out var url)
+            || string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        sessionId = sid;
+        screenShareUrl = url;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the conversation's active W365 session and its screenShareUrl. Returns the
+    /// start-time cached value when available; otherwise falls back to a GetSessionDetails call
+    /// against the live session (and caches the result). Used by the deterministic "give me a
+    /// screen share link" path, where the model has no tool to satisfy the request.
+    /// </summary>
+    public async Task<(bool Found, string SessionId, string ScreenShareUrl)> TryGetActiveScreenShareAsync(
+        string conversationId, CancellationToken ct = default)
+    {
+        if (TryGetActiveScreenShare(conversationId, out var cachedSid, out var cachedUrl))
+        {
+            return (true, cachedSid, cachedUrl);
+        }
+
+        if (string.IsNullOrWhiteSpace(conversationId)) return (false, string.Empty, string.Empty);
+        if (!_sessions.TryGetValue(conversationId, out var session)) return (false, string.Empty, string.Empty);
+
+        var sessionId = session.W365SessionId;
+        if (string.IsNullOrWhiteSpace(sessionId)) return (false, string.Empty, string.Empty);
+
+        var mcpClient = _w365McpClientsBySessionId.TryGetValue(sessionId, out var perSessionClient)
+            ? perSessionClient
+            : _cachedMcpClient;
+        if (mcpClient == null && _cachedTools == null)
+        {
+            return (false, string.Empty, string.Empty);
+        }
+
+        try
+        {
+            var args = new Dictionary<string, object?> { ["sessionId"] = sessionId };
+            var resultStr = await InvokeW365ToolAsync(_cachedTools ?? [], mcpClient, W365GetSessionDetailsToolName, args, ct)
+                .ConfigureAwait(false);
+
+            if (TryExtractStringProperty(resultStr, "screenShareUrl", out var freshUrl)
+                && !string.IsNullOrWhiteSpace(freshUrl))
+            {
+                session.ScreenShareUrlsBySessionId[sessionId] = freshUrl;
+                _logger.LogInformation("Fetched screenShareUrl via GetSessionDetails for session {SessionId} (start-time capture had none).", sessionId);
+                return (true, sessionId, freshUrl);
+            }
+
+            _logger.LogWarning("GetSessionDetails for session {SessionId} returned no screenShareUrl.", sessionId);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to fetch screenShareUrl via GetSessionDetails for session {SessionId}.", sessionId);
+        }
+
+        return (false, string.Empty, string.Empty);
     }
 
     internal async Task<W365McpToolListResult> StartDirectW365SessionAndListToolsAsync(
@@ -2197,6 +2307,11 @@ public class ComputerUseOrchestrator
                 if (TryExtractStringProperty(resultStr, "sessionId", out var sessionId))
                 {
                     session.TrackAndSelectSession(sessionId);
+                    if (TryExtractStringProperty(resultStr, "screenShareUrl", out var screenShareUrl)
+                        && !string.IsNullOrWhiteSpace(screenShareUrl))
+                    {
+                        session.ScreenShareUrlsBySessionId[sessionId] = screenShareUrl;
+                    }
                     _logger.LogInformation("Stored explicit W365 session {SessionId} from model-requested StartSession", sessionId);
                 }
             }
@@ -2391,6 +2506,18 @@ public class ComputerUseOrchestrator
         public int ScreenshotCounter { get; set; }
         public string? ScreenshotSubfolder { get; set; }
         public bool FolderShared { get; set; }
+
+        /// <summary>
+        /// screenShareUrl captured per W365 session id (from StartSession or a GetSessionDetails
+        /// fallback). Used to build the browser handoff link the agent posts in chat.
+        /// </summary>
+        public Dictionary<string, string> ScreenShareUrlsBySessionId { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Guards one-time emission of the screen-share link per session lifetime so the link
+        /// isn't re-posted on every turn. A fresh link is re-minted on explicit user request.
+        /// </summary>
+        public bool ScreenShareLinkEmitted { get; set; }
 
         /// <summary>
         /// Serializes turns for this conversation so two concurrent turns cannot both append a

--- a/dotnet/w365-computer-use/sample-agent/ComputerUse/W365McpSessionClient.cs
+++ b/dotnet/w365-computer-use/sample-agent/ComputerUse/W365McpSessionClient.cs
@@ -34,7 +34,15 @@ internal sealed class W365McpSessionClient
             throw new InvalidOperationException("W365 StartSession did not return a sessionId.");
         }
 
-        return await ListToolsAsync(sessionId, cancellationToken);
+        // Capture the screenShareUrl from the StartSession response so the prestart path can
+        // emit a screen-share link. (The in-turn StartSession that normally drives emission
+        // is skipped when the session is prestarted out-of-band.)
+        TryExtractStringProperty(startResultJson, "screenShareUrl", out var screenShareUrl);
+
+        var result = await ListToolsAsync(sessionId, cancellationToken);
+        return string.IsNullOrWhiteSpace(screenShareUrl)
+            ? result
+            : result with { ScreenShareUrl = screenShareUrl };
     }
 
     public async Task<W365McpToolListResult> ListToolsAsync(string sessionId, CancellationToken cancellationToken)
@@ -224,4 +232,12 @@ internal sealed class W365McpSessionClient
     }
 }
 
-internal sealed record W365McpToolListResult(string SessionId, IList<AITool> Tools, IMcpClient Client);
+internal sealed record W365McpToolListResult(string SessionId, IList<AITool> Tools, IMcpClient Client)
+{
+    /// <summary>
+    /// screenShareUrl captured from the StartSession response (prestart path only). Null when
+    /// the session was reused/listed rather than freshly started, or when the platform did not
+    /// return a screenShareUrl.
+    /// </summary>
+    public string? ScreenShareUrl { get; init; }
+}

--- a/dotnet/w365-computer-use/sample-agent/Program.cs
+++ b/dotnet/w365-computer-use/sample-agent/Program.cs
@@ -4,6 +4,7 @@
 using W365ComputerUseSample;
 using W365ComputerUseSample.Agent;
 using W365ComputerUseSample.ComputerUse;
+using W365ComputerUseSample.ScreenShare;
 using W365ComputerUseSample.Telemetry;
 using Microsoft.Agents.A365.Observability;
 using Microsoft.Agents.A365.Observability.Extensions.AgentFramework;
@@ -14,7 +15,12 @@ using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Storage;
+using Microsoft.AspNetCore.RateLimiting;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -48,8 +54,38 @@ builder.Services.AddSingleton<ICuaModelProvider, AzureOpenAIModelProvider>();
 // Register the Computer Use orchestrator
 builder.Services.AddSingleton<ComputerUseOrchestrator>();
 
+// Bind ScreenShare options consumed by the link the agent posts in chat and by the
+// screenshare SPA / token-exchange endpoint.
+builder.Services.Configure<ScreenShareOptions>(
+    builder.Configuration.GetSection(ScreenShareOptions.SectionName));
+
+// In-memory bridge from chat link (sid + hc) to ARI bearer token. Single-process only;
+// for multi-instance hosts swap for a distributed store (Redis, etc.).
+builder.Services.AddSingleton<HandoffStore>();
+
 // Add AspNet token validation
 builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+
+// Rate limit the screenshare token endpoint at (sid, ip) = 5 req / 60 s. Defense in depth
+// against link-brute-force; real protection is the 256-bit HC.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy("ScreenShareToken", httpContext =>
+    {
+        var sid = httpContext.Request.RouteValues["sid"]?.ToString() ?? "unknown";
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: $"{sid}|{ip}",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 5,
+                Window = TimeSpan.FromSeconds(60),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            });
+    });
+});
 
 // Register IStorage. For development, MemoryStorage is suitable.
 builder.Services.AddSingleton<IStorage, MemoryStorage>();
@@ -70,6 +106,53 @@ if (app.Environment.IsDevelopment())
 app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
+
+// Serve the screenshare SPA (wwwroot/screenshare.html + screenshare.js) so the user can open
+// the link the agent posts in chat.
+//
+// Set frame-ancestors via a real HTTP response header (browsers ignore it when delivered
+// through <meta> per CSP spec). Driven by ScreenShare:AllowedFrameAncestors so it's
+// env-configurable (Teams + new-Teams in prod). Also strip X-Frame-Options if anything sets it
+// — it would conflict with frame-ancestors for Teams.
+var ssOpts = builder.Configuration.GetSection(ScreenShareOptions.SectionName).Get<ScreenShareOptions>() ?? new ScreenShareOptions();
+
+// Fail fast on an unsafe screenshare auth configuration. DevBypass skips the viewer's identity
+// (owner) check and must never be reachable in a non-development deployment.
+var isDevEnvironment = app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground";
+if (ssOpts.AuthMode == ScreenShareAuthMode.DevBypass && !isDevEnvironment)
+{
+    throw new InvalidOperationException(
+        "ScreenShare:AuthMode=DevBypass is only permitted when ASPNETCORE_ENVIRONMENT is Development or Playground. " +
+        "Use AuthMode=EasyAuth for production deployments.");
+}
+
+var frameAncestors = (ssOpts.AllowedFrameAncestors is { Length: > 0 } fa)
+    ? string.Join(' ', fa)
+    : "'self'";
+app.Use(async (context, next) =>
+{
+    var path = context.Request.Path;
+    var isSpaHtml = path.Equals("/screenshare.html", StringComparison.OrdinalIgnoreCase);
+    var isSpaJs = path.Equals("/screenshare.js", StringComparison.OrdinalIgnoreCase);
+    if (isSpaHtml || isSpaJs)
+    {
+        context.Response.OnStarting(() =>
+        {
+            // Never cache the SPA shell/script — they change between dev iterations and carry no
+            // version in the URL. The versioned viewer bundle still caches.
+            context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+            if (isSpaHtml)
+            {
+                context.Response.Headers["Content-Security-Policy"] = $"frame-ancestors {frameAncestors};";
+                context.Response.Headers.Remove("X-Frame-Options");
+            }
+            return Task.CompletedTask;
+        });
+    }
+    await next();
+});
+app.UseStaticFiles();
 
 // Map the /api/messages endpoint to the AgentApplication
 app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, IAgent agent, CancellationToken cancellationToken) =>
@@ -88,6 +171,70 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
 // Health check endpoint for CI/CD pipelines and monitoring
 app.MapGet("/api/health", () => Results.Ok(new { status = "healthy", timestamp = DateTime.UtcNow }));
 
+// SPA config probe so screenshare.js gets the CDN origin + SDK version templated server-side
+// (one source of truth — no risk of HTML/JS drift).
+app.MapGet("/api/screenshare/config", () => Results.Ok(new
+{
+    cdnOrigin = ssOpts.CdnOrigin,
+    sdkVersion = ssOpts.SdkVersion,
+    authMode = ssOpts.AuthMode.ToString(),
+}));
+
+// Exchange the chat-link (sid + hc) for the ARI bearer token. How the viewer's identity is
+// established depends on ScreenShare:AuthMode:
+//   - EasyAuth (prod): the page sits behind Azure App Service Authentication, which authenticates
+//     the browser and injects the signed-in user's object id via X-MS-CLIENT-PRINCIPAL(-ID). We
+//     match that oid against the handoff owner so only the user who received the link can complete
+//     the exchange.
+//   - DevBypass (local/Playground only): the owner check is skipped so the sample can run in a
+//     plain browser tab. Hard-gated at startup to development environments.
+// The handoff record is burned atomically on success — any subsequent valid call returns 403.
+app.MapPost("/api/screenshare/{sid}/token", (
+        HttpContext http,
+        string sid,
+        TokenRequest req,
+        HandoffStore store,
+        ILogger<Program> logger) =>
+    {
+        var devBypass = ssOpts.AuthMode == ScreenShareAuthMode.DevBypass;
+        var oid = devBypass ? null : ScreenShareEasyAuth.GetEasyAuthObjectId(http);
+
+        void Log(string outcome, string? hcHashPrefix = null) =>
+            logger.LogInformation(
+                "Screenshare token: sid={Sid} authMode={AuthMode} oid={Oid} ip={Ip} outcome={Outcome} hcHashPrefix={HcHashPrefix}",
+                sid, ssOpts.AuthMode, oid ?? "(none)", http.Connection.RemoteIpAddress, outcome, hcHashPrefix ?? string.Empty);
+
+        // Defense-in-depth response headers — the body carries the bearer token.
+        http.Response.Headers["Cache-Control"] = "no-store";
+        http.Response.Headers["X-Frame-Options"] = "DENY";
+
+        if (!Guid.TryParseExact(sid, "D", out _)) { Log("InvalidSid"); return Results.BadRequest(new { error = "invalid sid" }); }
+        if (req is null || string.IsNullOrEmpty(req.Hc) || req.Hc.Length < 32 || req.Hc.Length > 64)
+        { Log("InvalidHc"); return Results.BadRequest(new { error = "invalid hc" }); }
+
+        // EasyAuth must have authenticated the user. Missing oid means the request did not come
+        // through the authenticated edge — refuse rather than skip the owner check. (DevBypass
+        // intentionally has no oid; the owner check below is skipped.)
+        if (!devBypass && string.IsNullOrEmpty(oid)) { Log("NoOid"); return Results.Unauthorized(); }
+
+        if (!store.TryGet(sid, out var rec) || rec is null) { Log("NotFound"); return Results.NotFound(); }
+        if (rec.Burned == 1 || rec.HandoffExpiresAtUtc < DateTime.UtcNow) { Log("ExpiredOrBurned"); return Results.Forbid(); }
+
+        var hcHash = SHA256.HashData(Encoding.UTF8.GetBytes(req.Hc));
+        if (!CryptographicOperations.FixedTimeEquals(hcHash, rec.HandoffCodeHash)) { Log("HashMismatch"); return Results.Forbid(); }
+        if (!devBypass && !string.Equals(oid, rec.OwnerAadObjectId, StringComparison.Ordinal)) { Log("OidMismatch"); return Results.Forbid(); }
+        if (!store.TryBurn(sid)) { Log("RaceLost"); return Results.Forbid(); }
+
+        Log(devBypass ? "IssuedDevBypass" : "Issued", Convert.ToHexString(hcHash, 0, 4));
+        return Results.Ok(new
+        {
+            screenShareUrl = rec.ScreenShareUrl,
+            ariToken = rec.AriToken,
+            expiresAtUtc = rec.AriTokenExpiresAtUtc
+        });
+    })
+    .RequireRateLimiting("ScreenShareToken");
+
 if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "W365 Computer Use Sample Agent");
@@ -97,6 +244,8 @@ if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playg
     // Hard coded for brevity and ease of testing.
     // In production, this should be set in configuration.
     app.Urls.Add("http://localhost:3978");
+    // HTTPS listener required for the screenshare SPA (secure context for postMessage to CDN iframe).
+    app.Urls.Add("https://localhost:3979");
 }
 else
 {
@@ -111,3 +260,51 @@ app.Lifetime.ApplicationStopping.Register(() =>
 });
 
 app.Run();
+
+/// <summary>
+/// Reads the signed-in user's Entra object id (oid) from the headers Azure App Service
+/// Authentication (EasyAuth) injects after authenticating the browser. Prefers the
+/// objectidentifier claim parsed from the base64 <c>X-MS-CLIENT-PRINCIPAL</c> payload; falls back
+/// to the <c>X-MS-CLIENT-PRINCIPAL-ID</c> header (the oid for the AAD provider). Returns
+/// <c>null</c> when no EasyAuth principal is present.
+/// </summary>
+static class ScreenShareEasyAuth
+{
+    internal static string? GetEasyAuthObjectId(HttpContext http)
+    {
+        var principalB64 = http.Request.Headers["X-MS-CLIENT-PRINCIPAL"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(principalB64))
+        {
+            try
+            {
+                var json = Encoding.UTF8.GetString(Convert.FromBase64String(principalB64));
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("claims", out var claims)
+                    && claims.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var c in claims.EnumerateArray())
+                    {
+                        var typ = c.TryGetProperty("typ", out var t) ? t.GetString() : null;
+                        if (typ is "http://schemas.microsoft.com/identity/claims/objectidentifier" or "oid")
+                        {
+                            return c.TryGetProperty("val", out var v) ? v.GetString() : null;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Malformed header — fall through to the principal-id header.
+            }
+        }
+
+        var principalId = http.Request.Headers["X-MS-CLIENT-PRINCIPAL-ID"].FirstOrDefault();
+        return string.IsNullOrEmpty(principalId) ? null : principalId;
+    }
+}
+
+/// <summary>
+/// Body for <c>POST /api/screenshare/{sid}/token</c>. <c>sid</c> stays in the route so the rate
+/// limiter can key on it before model binding.
+/// </summary>
+internal sealed record TokenRequest(string Hc);

--- a/dotnet/w365-computer-use/sample-agent/Program.cs
+++ b/dotnet/w365-computer-use/sample-agent/Program.cs
@@ -74,7 +74,13 @@ builder.Services.AddRateLimiter(options =>
     options.AddPolicy("ScreenShareToken", httpContext =>
     {
         var sid = httpContext.Request.RouteValues["sid"]?.ToString() ?? "unknown";
-        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        // Prefer the client IP from X-Forwarded-For (App Service / reverse proxies terminate the
+        // connection, so RemoteIpAddress is the proxy). Take the first (original client) hop; fall
+        // back to RemoteIpAddress when the header is absent.
+        var forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        var ip = !string.IsNullOrWhiteSpace(forwardedFor)
+            ? forwardedFor.Split(',')[0].Trim()
+            : httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         return RateLimitPartition.GetFixedWindowLimiter(
             partitionKey: $"{sid}|{ip}",
             factory: _ => new FixedWindowRateLimiterOptions

--- a/dotnet/w365-computer-use/sample-agent/Program.cs
+++ b/dotnet/w365-computer-use/sample-agent/Program.cs
@@ -117,14 +117,12 @@ app.UseRateLimiter();
 // Serve the screenshare SPA (wwwroot/screenshare.html + screenshare.js) so the user can open
 // the link the agent posts in chat.
 //
-// Set frame-ancestors via a real HTTP response header (browsers ignore it when delivered
-// through <meta> per CSP spec). Driven by ScreenShare:AllowedFrameAncestors so it's
-// env-configurable (Teams + new-Teams in prod). Also strip X-Frame-Options if anything sets it
-// — it would conflict with frame-ancestors for Teams.
+// frame-ancestors must be a real HTTP response header (browsers ignore it in <meta>). It's
+// driven by ScreenShare:AllowedFrameAncestors so it's env-configurable.
 var ssOpts = builder.Configuration.GetSection(ScreenShareOptions.SectionName).Get<ScreenShareOptions>() ?? new ScreenShareOptions();
 
-// Fail fast on an unsafe screenshare auth configuration. DevBypass skips the viewer's identity
-// (owner) check and must never be reachable in a non-development deployment.
+// Fail fast on an unsafe screenshare auth configuration: DevBypass skips the viewer's identity
+// check and must never be reachable in a non-development deployment.
 var isDevEnvironment = app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground";
 if (ssOpts.AuthMode == ScreenShareAuthMode.DevBypass && !isDevEnvironment)
 {
@@ -145,8 +143,7 @@ app.Use(async (context, next) =>
     {
         context.Response.OnStarting(() =>
         {
-            // Never cache the SPA shell/script — they change between dev iterations and carry no
-            // version in the URL. The versioned viewer bundle still caches.
+            // Never cache the SPA shell/script — they carry no version in the URL.
             context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
             if (isSpaHtml)
             {
@@ -177,8 +174,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
 // Health check endpoint for CI/CD pipelines and monitoring
 app.MapGet("/api/health", () => Results.Ok(new { status = "healthy", timestamp = DateTime.UtcNow }));
 
-// SPA config probe so screenshare.js gets the CDN origin + SDK version templated server-side
-// (one source of truth — no risk of HTML/JS drift).
+// SPA config probe: hands screenshare.js the CDN origin + SDK version so they live in one place.
 app.MapGet("/api/screenshare/config", () => Results.Ok(new
 {
     cdnOrigin = ssOpts.CdnOrigin,
@@ -186,15 +182,10 @@ app.MapGet("/api/screenshare/config", () => Results.Ok(new
     authMode = ssOpts.AuthMode.ToString(),
 }));
 
-// Exchange the chat-link (sid + hc) for the ARI bearer token. How the viewer's identity is
-// established depends on ScreenShare:AuthMode:
-//   - EasyAuth (prod): the page sits behind Azure App Service Authentication, which authenticates
-//     the browser and injects the signed-in user's object id via X-MS-CLIENT-PRINCIPAL(-ID). We
-//     match that oid against the handoff owner so only the user who received the link can complete
-//     the exchange.
-//   - DevBypass (local/Playground only): the owner check is skipped so the sample can run in a
-//     plain browser tab. Hard-gated at startup to development environments.
-// The handoff record is burned atomically on success — any subsequent valid call returns 403.
+// Exchange the chat-link (sid + hc) for the ARI bearer token. Under EasyAuth (prod) the signed-in
+// user's object id is matched against the handoff owner so only the recipient can complete the
+// exchange; DevBypass (local/Playground only) skips that check. The handoff is burned atomically
+// on success — any later valid call returns 403.
 app.MapPost("/api/screenshare/{sid}/token", (
         HttpContext http,
         string sid,

--- a/dotnet/w365-computer-use/sample-agent/README.md
+++ b/dotnet/w365-computer-use/sample-agent/README.md
@@ -186,6 +186,14 @@ dotnet run
 | `Screenshots:OneDriveUserId` | UPN/email to upload screenshots to a specific user's OneDrive (instead of token owner) | - |
 | `BEARER_TOKEN` (env var) | MCP Platform token with `Tools.ListInvoke.All` scope (dev only) | - |
 | `GRAPH_TOKEN` (env var) | Graph API token with `Files.ReadWrite` scope for OneDrive upload (dev only) | - |
+| `AgentApplication:ScreenShareAuthHandlerName` | Auth handler used to mint ARI screenshare tokens | `ari` |
+| `AgentApplication:UserAuthorization:Handlers:ari:Settings:Scopes` | ARI audience (production `90ecec28-f5a6-42b3-9bde-dae1ca98f8b5/.default`) | - |
+| `ScreenShare:AuthMode` | `EasyAuth` for Azure deployment, `DevBypass` for local development | `EasyAuth` |
+| `ScreenShare:SdkVersion` | Screenshare SDK version loaded from the CDN | `1.0.0` |
+| `ScreenShare:CdnOrigin` | Public Microsoft CDN origin for the screenshare SDK | `https://packages.global.cloudinferenceplatform.azure.com` |
+| `ScreenShare:PageBaseUrl` | Public base URL for links to `screenshare.html`; defaults to the App Service host if unset | - |
+| `ScreenShare:AllowedFrameAncestors` | CSP `frame-ancestors` values allowed to embed the screenshare page | Teams / M365 hosts |
+| `ARI_BEARER_TOKEN` (env var) | Optional local ARI token override for screenshare development | - |
 
 ## Supported Models
 
@@ -218,6 +226,39 @@ The tool type is auto-derived from the model name (`gpt-*` -> `computer`, otherw
 - Conversation history accumulates across messages, giving the model context for follow-up tasks
 - On app shutdown (`Ctrl+C`), the agent calls `EndSession` for each cached `sessionId` to release VMs back to the pool
 - If the app crashes, sessions auto-expire after ~30 minutes on the W365 backend
+
+## Screenshare
+
+The agent can expose a live screenshare link to the running Cloud PC through the W365 / ARI screenshare SDK. The link is created during the bot turn, when `turnContext` is available.
+
+1. The W365 MCP start-session response includes a `screenShareUrl`.
+2. The agent mints an ARI token through the `ari` auth handler, or uses `ARI_BEARER_TOKEN` in local development.
+3. The agent stores a one-time handoff record in memory (`HandoffStore`):
+   - `sessionId`
+   - `screenShareUrl`
+   - owner Entra object id from the original Teams activity
+   - hashed handoff code
+   - ARI token and parsed token expiry
+4. The bot posts a link to `/screenshare.html?sid=<sessionId>&hc=<handoffCode>`.
+5. The browser signs in through EasyAuth and calls `POST /api/screenshare/{sid}/token`.
+6. The server validates the EasyAuth identity against the original owner object id and returns the ARI token to the page.
+7. The page loads the screenshare SDK from `ScreenShare:CdnOrigin` and starts the session.
+
+The screenshare SDK is served from the public Microsoft CDN (`ScreenShare:CdnOrigin`, default `https://packages.global.cloudinferenceplatform.azure.com`); `/api/screenshare/config` templates the origin and SDK version so `screenshare.js` stays in sync.
+
+The in-memory handoff store is single-process. If the web app is scaled out to multiple instances, replace it with a distributed cache.
+
+### Local testing
+
+- Run the agent — it binds `http://localhost:3978` and `https://localhost:3979` (the SPA requires a secure context).
+- Set `ScreenShare:AuthMode` to `DevBypass` to skip the EasyAuth identity check locally.
+- Set `ARI_BEARER_TOKEN` to a valid ARI token so the page can start the SDK without EasyAuth.
+
+### Production
+
+- Enable App Service Authentication (EasyAuth) with Microsoft Entra ID so browser requests to `screenshare.html` are authenticated.
+- Set `ScreenShare:AuthMode=EasyAuth` and `ScreenShare:PageBaseUrl=https://<webapp-name>.azurewebsites.net`.
+- Register the `ari` auth handler scopes and grant the agent identity the ARI screenshare permissions on the target W365 Cloud PC pool.
 
 ## Production Deployment
 

--- a/dotnet/w365-computer-use/sample-agent/ScreenShare/HandoffStore.cs
+++ b/dotnet/w365-computer-use/sample-agent/ScreenShare/HandoffStore.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+
+namespace W365ComputerUseSample.ScreenShare;
+
+/// <summary>
+/// In-memory record bridging the chat link the agent posts to the browser
+/// authenticated POST that exchanges the one-time handoff code (HC) for the ARI
+/// bearer token. Single-process only — for multi-instance hosting, swap for a
+/// distributed store (Redis, etc.).
+/// </summary>
+public sealed class HandoffRecord
+{
+    public required string ScreenShareUrl { get; init; }
+    public required string OwnerAadObjectId { get; init; }
+    public required byte[] HandoffCodeHash { get; init; }
+    public required DateTime HandoffExpiresAtUtc { get; init; }
+    public required string AriToken { get; init; }
+    public required DateTime AriTokenExpiresAtUtc { get; init; }
+
+    /// <summary>
+    /// 0 = unburned, 1 = burned. Manipulated via <see cref="Interlocked.CompareExchange(ref int, int, int)"/>
+    /// so two parallel valid requests cannot both succeed.
+    /// </summary>
+    public int Burned;
+}
+
+/// <summary>
+/// Tracks per-session handoff records. Each record lives at most <c>HandoffExpiresAtUtc</c>
+/// (5-minute HC TTL) — a background timer sweeps burned and expired entries every 60 seconds.
+/// </summary>
+public sealed class HandoffStore : IDisposable
+{
+    private readonly ConcurrentDictionary<string, HandoffRecord> _dict = new(StringComparer.Ordinal);
+    private readonly Timer _cleanupTimer;
+
+    public HandoffStore()
+    {
+        // Single timer, every 60 s, removes burned or HC-expired records.
+        _cleanupTimer = new Timer(_ => Cleanup(), null, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(60));
+    }
+
+    public void Set(string sid, HandoffRecord rec) => _dict[sid] = rec;
+
+    public bool TryGet(string sid, out HandoffRecord? rec) => _dict.TryGetValue(sid, out rec);
+
+    /// <summary>
+    /// Atomic compare-and-swap: returns <c>true</c> exactly once per record. All
+    /// subsequent callers (including races) see <c>false</c>.
+    /// </summary>
+    public bool TryBurn(string sid)
+    {
+        if (!_dict.TryGetValue(sid, out var rec)) return false;
+        return Interlocked.CompareExchange(ref rec.Burned, 1, 0) == 0;
+    }
+
+    private void Cleanup()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var kvp in _dict)
+        {
+            if (kvp.Value.Burned == 1 || kvp.Value.HandoffExpiresAtUtc < now)
+            {
+                _dict.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+
+    public void Dispose() => _cleanupTimer.Dispose();
+}

--- a/dotnet/w365-computer-use/sample-agent/ScreenShare/ScreenShareOptions.cs
+++ b/dotnet/w365-computer-use/sample-agent/ScreenShare/ScreenShareOptions.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace W365ComputerUseSample.ScreenShare;
+
+/// <summary>
+/// How the screenshare token-exchange endpoint establishes the identity of the user
+/// viewing the page. Selected via <c>ScreenShare:AuthMode</c>.
+/// </summary>
+public enum ScreenShareAuthMode
+{
+    /// <summary>
+    /// PROD / Azure App Service. The page sits behind Azure App Service Authentication
+    /// (EasyAuth): the platform signs the browser in through Entra and injects the
+    /// authenticated user's object id via the <c>X-MS-CLIENT-PRINCIPAL(-ID)</c> headers,
+    /// which the token endpoint matches against the handoff owner. The default.
+    /// </summary>
+    EasyAuth,
+
+    /// <summary>
+    /// LOCAL DEV / Playground only. The token endpoint skips the user-identity (owner)
+    /// check so the sample can run end-to-end in a plain browser tab against a local
+    /// agent — typically paired with the <c>ARI_BEARER_TOKEN</c> env var so no agentic
+    /// token plumbing is required. The handoff burn, HC hash, expiry, and rate limit
+    /// still apply. Hard-gated: startup throws if this is selected outside
+    /// <c>ASPNETCORE_ENVIRONMENT=Development</c> (or <c>Playground</c>).
+    /// </summary>
+    DevBypass,
+}
+
+/// <summary>
+/// Options bound from the "ScreenShare" config section. Drives the static SPA at
+/// /screenshare.html and the link the agent posts in chat.
+///
+/// The user viewing the page is authenticated according to <see cref="AuthMode"/>
+/// (EasyAuth in production, DevBypass for local testing). The ARI bearer token is
+/// always minted server-side by the agent (see MyAgent.BuildScreenSharePageUrlAsync).
+/// Teams SSO (page embedded inside Teams as a tab/dialog/stage) is a documented
+/// future extension and is intentionally not implemented in this sample.
+/// </summary>
+public sealed class ScreenShareOptions
+{
+    public const string SectionName = "ScreenShare";
+
+    /// <summary>
+    /// How the token-exchange endpoint establishes the viewer's identity. Defaults to
+    /// <see cref="ScreenShareAuthMode.EasyAuth"/> (production). Set to
+    /// <see cref="ScreenShareAuthMode.DevBypass"/> only for local/Playground testing —
+    /// startup fails fast if DevBypass is selected outside a development environment.
+    /// </summary>
+    public ScreenShareAuthMode AuthMode { get; set; } = ScreenShareAuthMode.EasyAuth;
+
+    /// <summary>
+    /// Absolute base URL where the SPA is served. When empty, the agent falls back to
+    /// <c>WEBSITE_HOSTNAME</c> (auto-populated on Azure App Service); when neither is
+    /// available the screenshare link emission is skipped.
+    /// </summary>
+    public string? PageBaseUrl { get; set; }
+
+    /// <summary>
+    /// W365 ScreenShare SDK version path on the CDN — e.g. <c>1.0.0</c> (pinned, preferred for prod)
+    /// or <c>latest</c> (~5-minute CDN cache, dev only). The SPA loads
+    /// <c>{CdnOrigin}/screenshare-sdk/{SdkVersion}/screenshare-embed.js</c> and passes
+    /// <c>{CdnOrigin}/screenshare-sdk/{SdkVersion}</c> as <c>viewerUrl</c> to the SDK so the
+    /// iframe is loaded from the CDN (origin already allowlisted by ARI — no partner-side CORS).
+    /// </summary>
+    public string SdkVersion { get; set; } = "1.0.0";
+
+    /// <summary>
+    /// CDN origin serving the W365 ScreenShare SDK and viewer.
+    /// <list type="bullet">
+    ///   <item><c>https://packages.global.cloudinferenceplatform.azure.com</c> — PROD (default).</item>
+    ///   <item><c>https://packages.global.cloudinferenceplatform-int.azure.com</c> — INT.</item>
+    /// </list>
+    /// Must match the ARI audience environment of the bearer tokens the agent mints.
+    /// </summary>
+    public string CdnOrigin { get; set; } = "https://packages.global.cloudinferenceplatform.azure.com";
+
+    /// <summary>
+    /// Origins allowed to iframe <c>/screenshare.html</c>. Emitted as
+    /// <c>Content-Security-Policy: frame-ancestors</c> on the response (the
+    /// <c>&lt;meta&gt;</c> form of <c>frame-ancestors</c> is ignored by browsers
+    /// per CSP spec). In prod this typically includes <c>https://teams.microsoft.com</c>,
+    /// <c>https://*.teams.microsoft.com</c>, and <c>https://*.cloud.microsoft</c> (new Teams).
+    /// </summary>
+    public string[] AllowedFrameAncestors { get; set; } = Array.Empty<string>();
+}

--- a/dotnet/w365-computer-use/sample-agent/ScreenShare/ScreenShareOptions.cs
+++ b/dotnet/w365-computer-use/sample-agent/ScreenShare/ScreenShareOptions.cs
@@ -10,78 +10,56 @@ namespace W365ComputerUseSample.ScreenShare;
 public enum ScreenShareAuthMode
 {
     /// <summary>
-    /// PROD / Azure App Service. The page sits behind Azure App Service Authentication
-    /// (EasyAuth): the platform signs the browser in through Entra and injects the
-    /// authenticated user's object id via the <c>X-MS-CLIENT-PRINCIPAL(-ID)</c> headers,
-    /// which the token endpoint matches against the handoff owner. The default.
+    /// Production. The page sits behind Azure App Service Authentication (EasyAuth), which
+    /// signs the user in and lets the token endpoint verify their identity. The default.
     /// </summary>
     EasyAuth,
 
     /// <summary>
-    /// LOCAL DEV / Playground only. The token endpoint skips the user-identity (owner)
-    /// check so the sample can run end-to-end in a plain browser tab against a local
-    /// agent — typically paired with the <c>ARI_BEARER_TOKEN</c> env var so no agentic
-    /// token plumbing is required. The handoff burn, HC hash, expiry, and rate limit
-    /// still apply. Hard-gated: startup throws if this is selected outside
-    /// <c>ASPNETCORE_ENVIRONMENT=Development</c> (or <c>Playground</c>).
+    /// Local dev / Playground only. The token endpoint skips the user-identity check so the
+    /// sample can run in a plain browser tab, typically with the <c>ARI_BEARER_TOKEN</c> env
+    /// var. Startup fails fast if selected outside a development environment.
     /// </summary>
     DevBypass,
 }
 
 /// <summary>
-/// Options bound from the "ScreenShare" config section. Drives the static SPA at
-/// /screenshare.html and the link the agent posts in chat.
-///
-/// The user viewing the page is authenticated according to <see cref="AuthMode"/>
-/// (EasyAuth in production, DevBypass for local testing). The ARI bearer token is
-/// always minted server-side by the agent (see MyAgent.BuildScreenSharePageUrlAsync).
-/// Teams SSO (page embedded inside Teams as a tab/dialog/stage) is a documented
-/// future extension and is intentionally not implemented in this sample.
+/// Options bound from the "ScreenShare" config section. Drives the SPA at /screenshare.html
+/// and the link the agent posts in chat.
 /// </summary>
 public sealed class ScreenShareOptions
 {
     public const string SectionName = "ScreenShare";
 
     /// <summary>
-    /// How the token-exchange endpoint establishes the viewer's identity. Defaults to
-    /// <see cref="ScreenShareAuthMode.EasyAuth"/> (production). Set to
-    /// <see cref="ScreenShareAuthMode.DevBypass"/> only for local/Playground testing —
-    /// startup fails fast if DevBypass is selected outside a development environment.
+    /// How the token endpoint establishes the viewer's identity. Defaults to
+    /// <see cref="ScreenShareAuthMode.EasyAuth"/>; use <see cref="ScreenShareAuthMode.DevBypass"/>
+    /// only for local/Playground testing.
     /// </summary>
     public ScreenShareAuthMode AuthMode { get; set; } = ScreenShareAuthMode.EasyAuth;
 
     /// <summary>
-    /// Absolute base URL where the SPA is served. When empty, the agent falls back to
-    /// <c>WEBSITE_HOSTNAME</c> (auto-populated on Azure App Service); when neither is
-    /// available the screenshare link emission is skipped.
+    /// Absolute base URL where the SPA is served. When empty, falls back to
+    /// <c>WEBSITE_HOSTNAME</c> (auto-populated on Azure App Service); when neither is set the
+    /// screenshare link is not emitted.
     /// </summary>
     public string? PageBaseUrl { get; set; }
 
     /// <summary>
-    /// W365 ScreenShare SDK version path on the CDN — e.g. <c>1.0.0</c> (pinned, preferred for prod)
-    /// or <c>latest</c> (~5-minute CDN cache, dev only). The SPA loads
-    /// <c>{CdnOrigin}/screenshare-sdk/{SdkVersion}/screenshare-embed.js</c> and passes
-    /// <c>{CdnOrigin}/screenshare-sdk/{SdkVersion}</c> as <c>viewerUrl</c> to the SDK so the
-    /// iframe is loaded from the CDN (origin already allowlisted by ARI — no partner-side CORS).
+    /// Screenshare SDK version to load from the CDN — e.g. <c>1.0.0</c>.
     /// </summary>
     public string SdkVersion { get; set; } = "1.0.0";
 
     /// <summary>
-    /// CDN origin serving the W365 ScreenShare SDK and viewer.
-    /// <list type="bullet">
-    ///   <item><c>https://packages.global.cloudinferenceplatform.azure.com</c> — PROD (default).</item>
-    ///   <item><c>https://packages.global.cloudinferenceplatform-int.azure.com</c> — INT.</item>
-    /// </list>
-    /// Must match the ARI audience environment of the bearer tokens the agent mints.
+    /// CDN origin serving the screenshare SDK and viewer. Must match the environment of the
+    /// ARI bearer tokens the agent mints.
     /// </summary>
     public string CdnOrigin { get; set; } = "https://packages.global.cloudinferenceplatform.azure.com";
 
     /// <summary>
-    /// Origins allowed to iframe <c>/screenshare.html</c>. Emitted as
-    /// <c>Content-Security-Policy: frame-ancestors</c> on the response (the
-    /// <c>&lt;meta&gt;</c> form of <c>frame-ancestors</c> is ignored by browsers
-    /// per CSP spec). In prod this typically includes <c>https://teams.microsoft.com</c>,
-    /// <c>https://*.teams.microsoft.com</c>, and <c>https://*.cloud.microsoft</c> (new Teams).
+    /// Origins allowed to iframe <c>/screenshare.html</c>, emitted as the
+    /// <c>Content-Security-Policy: frame-ancestors</c> response header. In production this
+    /// typically includes the Teams / M365 hosts that embed the page.
     /// </summary>
     public string[] AllowedFrameAncestors { get; set; } = Array.Empty<string>();
 }

--- a/dotnet/w365-computer-use/sample-agent/appsettings.json
+++ b/dotnet/w365-computer-use/sample-agent/appsettings.json
@@ -5,6 +5,7 @@
     "NormalizeMentions": false,
     "AgenticAuthHandlerName": "agentic",
     "W365AuthHandlerName": "w365",
+    "ScreenShareAuthHandlerName": "ari",
     "UserAuthorization": {
       "AutoSignin": false,
       "Handlers": {
@@ -21,6 +22,14 @@
           "Settings": {
             "Scopes": [
               "da81128c-e5b5-4f9e-8d89-50d906f107c5/.default"
+            ]
+          }
+        },
+        "ari": {
+          "Type": "AgenticUserAuthorization",
+          "Settings": {
+            "Scopes": [
+              "90ecec28-f5a6-42b3-9bde-dae1ca98f8b5/.default"
             ]
           }
         }
@@ -85,5 +94,19 @@
     "LocalPath": "./Screenshots",
     "OneDriveFolder": "CUA-Sessions",
     "OneDriveUserId": ""
+  },
+
+  "ScreenShare": {
+    "AuthMode": "EasyAuth",
+    "SdkVersion": "1.0.0",
+    "CdnOrigin": "https://packages.global.cloudinferenceplatform.azure.com",
+    "PageBaseUrl": "<<YOUR_SCREENSHARE_PAGE_BASE_URL>>",
+    "AllowedFrameAncestors": [
+      "'self'",
+      "https://teams.microsoft.com",
+      "https://*.teams.microsoft.com",
+      "https://*.cloud.microsoft",
+      "https://*.microsoft365.com"
+    ]
   }
 }

--- a/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.html
+++ b/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.html
@@ -1,0 +1,86 @@
+<!--
+  Copyright (c) Microsoft Corporation.
+  Licensed under the MIT License.
+
+  Screenshare SPA — opened from the link the agent posts in chat.
+  Reads ?sid=...&hc=... from the URL and exchanges sid+hc for the ARI bearer token
+  at POST /api/screenshare/{sid}/token, then mounts the W365 screenshare SDK 1.0.0
+  viewer loaded from the public CDN.
+
+  Authentication: the page (and the token endpoint) sit behind Azure App Service
+  Authentication (EasyAuth). When the user clicks the chat link the platform sends
+  the browser through Entra sign-in; once authenticated, EasyAuth injects the user's
+  object id into the X-MS-CLIENT-PRINCIPAL-ID request header which the token endpoint
+  matches against the handoff owner. No teams-js / Teams SSO is required.
+
+  The SDK + viewer iframe are loaded from the public W365 CDN — the iframe origin
+  is therefore the CDN, which ARI already allowlists. Partner pages no longer need
+  their own origin allowlisted in ARI CORS. See PARTNER_GUIDE in the official
+  screenshare-host-starter for the full architecture.
+
+  The SDK URL + version are templated server-side from ScreenShare:CdnOrigin and
+  ScreenShare:SdkVersion. The CSP `script-src`, `connect-src`, and `frame-src`
+  entries must include the CDN origin.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--
+      CSP for the SPA page itself. The viewer iframe (embed.html under
+      {CdnOrigin}/screenshare-sdk/{version}/) is cross-origin, served by the
+      W365 public CDN — listed below in frame-src.
+      frame-ancestors is NOT here — it is ignored by browsers when delivered via
+      <meta> (per CSP spec). It is set as a real HTTP response header by the
+      middleware in Program.cs (driven by ScreenShare:AllowedFrameAncestors).
+    -->
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'self';
+        script-src  'self' https://packages.global.cloudinferenceplatform.azure.com https://packages.global.cloudinferenceplatform-int.azure.com;
+        style-src   'self' 'unsafe-inline';
+        img-src     'self' data:;
+        connect-src 'self';
+        frame-src   https://packages.global.cloudinferenceplatform.azure.com https://packages.global.cloudinferenceplatform-int.azure.com;
+    " />
+    <title>W365 Screen Share</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 16px; background: #f3f3f3; color: #1f1f1f; }
+        header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+        header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+        #status { font-size: 13px; color: #555; flex: 1; }
+        #status.error { color: #c4314b; font-weight: 600; }
+        #controls { display: flex; gap: 8px; margin-bottom: 12px; }
+        button { padding: 6px 14px; font-size: 13px; border: 1px solid #ccc; background: #fff; border-radius: 4px; cursor: pointer; }
+        button:disabled { opacity: 0.5; cursor: not-allowed; }
+        button.primary { background: #0078d4; color: #fff; border-color: #0078d4; }
+        #viewer { width: 100%; height: 80vh; background: #000; border: 1px solid #ccc; border-radius: 4px; }
+        #error-detail { font-size: 12px; color: #888; margin-top: 8px; white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>W365 Screen Share</h1>
+        <span id="status">Initializing…</span>
+    </header>
+
+    <div id="controls">
+        <button id="btn-take" disabled>Take control</button>
+        <button id="btn-release" disabled>Release control</button>
+        <button id="btn-stop" disabled>Stop session</button>
+    </div>
+
+    <div id="viewer"></div>
+
+    <div id="error-detail"></div>
+
+    <!--
+      W365 ScreenShare SDK is loaded dynamically by screenshare.js from
+      {ScreenShare:CdnOrigin}/screenshare-sdk/{ScreenShare:SdkVersion}/screenshare-embed.js
+      after fetching /api/screenshare/config. Keeping the SDK load there means a single
+      source of truth for CDN origin + version (no risk of HTML/JS drift).
+    -->
+    <!-- App bootstrap. -->
+    <script src="/screenshare.js"></script>
+</body>
+</html>

--- a/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.html
+++ b/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.html
@@ -2,25 +2,14 @@
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
-  Screenshare SPA — opened from the link the agent posts in chat.
-  Reads ?sid=...&hc=... from the URL and exchanges sid+hc for the ARI bearer token
-  at POST /api/screenshare/{sid}/token, then mounts the W365 screenshare SDK 1.0.0
-  viewer loaded from the public CDN.
+  Screenshare SPA — opened from the link the agent posts in chat. Reads
+  ?sid=...&hc=... from the URL, exchanges them for the ARI bearer token at
+  POST /api/screenshare/{sid}/token, then mounts the screenshare viewer loaded
+  from the CDN. The CDN origin and SDK version come from ScreenShare:CdnOrigin
+  and ScreenShare:SdkVersion (served via /api/screenshare/config).
 
-  Authentication: the page (and the token endpoint) sit behind Azure App Service
-  Authentication (EasyAuth). When the user clicks the chat link the platform sends
-  the browser through Entra sign-in; once authenticated, EasyAuth injects the user's
-  object id into the X-MS-CLIENT-PRINCIPAL-ID request header which the token endpoint
-  matches against the handoff owner. No teams-js / Teams SSO is required.
-
-  The SDK + viewer iframe are loaded from the public W365 CDN — the iframe origin
-  is therefore the CDN, which ARI already allowlists. Partner pages no longer need
-  their own origin allowlisted in ARI CORS. See PARTNER_GUIDE in the official
-  screenshare-host-starter for the full architecture.
-
-  The SDK URL + version are templated server-side from ScreenShare:CdnOrigin and
-  ScreenShare:SdkVersion. The CSP `script-src`, `connect-src`, and `frame-src`
-  entries must include the CDN origin.
+  In production the page sits behind Azure App Service Authentication (EasyAuth),
+  which signs the user in and lets the token endpoint verify their identity.
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -28,12 +17,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <!--
-      CSP for the SPA page itself. The viewer iframe (embed.html under
-      {CdnOrigin}/screenshare-sdk/{version}/) is cross-origin, served by the
-      W365 public CDN — listed below in frame-src.
-      frame-ancestors is NOT here — it is ignored by browsers when delivered via
-      <meta> (per CSP spec). It is set as a real HTTP response header by the
-      middleware in Program.cs (driven by ScreenShare:AllowedFrameAncestors).
+      CSP for the SPA page. The viewer iframe is served cross-origin by the CDN
+      (listed in frame-src). frame-ancestors is set as a real HTTP response header
+      by Program.cs (browsers ignore it in <meta>).
     -->
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'self';
@@ -74,13 +60,7 @@
 
     <div id="error-detail"></div>
 
-    <!--
-      W365 ScreenShare SDK is loaded dynamically by screenshare.js from
-      {ScreenShare:CdnOrigin}/screenshare-sdk/{ScreenShare:SdkVersion}/screenshare-embed.js
-      after fetching /api/screenshare/config. Keeping the SDK load there means a single
-      source of truth for CDN origin + version (no risk of HTML/JS drift).
-    -->
-    <!-- App bootstrap. -->
+    <!-- SDK is loaded dynamically by screenshare.js after fetching /api/screenshare/config. -->
     <script src="/screenshare.js"></script>
 </body>
 </html>

--- a/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.js
+++ b/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.js
@@ -1,37 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// W365 Screen Share SPA bootstrap (SDK 1.0.0 public, agent-delegated user-token flow).
+// Screenshare SPA bootstrap. Opened from the link the agent posts in chat:
+//   1. Read sid + hc from the querystring.
+//   2. GET /api/screenshare/config for the CDN origin + SDK version.
+//   3. Load the screenshare SDK from the CDN.
+//   4. POST /api/screenshare/{sid}/token to exchange sid + hc for the ARI token.
+//   5. Mount the viewer and wire the Take / Release / Stop controls.
 //
-// Flow:
-//   1. Read sid + hc from querystring (the only two params the agent puts in the link).
-//   2. Fetch /api/screenshare/config — gets {cdnOrigin, sdkVersion}.
-//   3. Dynamically <script src=`{cdnOrigin}/screenshare-sdk/{sdkVersion}/screenshare-embed.js`>.
-//   4. POST /api/screenshare/{sid}/token with {hc} body. The page sits behind Azure
-//      App Service Authentication (EasyAuth), so the request carries the EasyAuth
-//      session cookie automatically (same-origin) and the server reads the user's
-//      object id from the X-MS-CLIENT-PRINCIPAL-ID header EasyAuth injects. No
-//      Authorization header / Teams SSO token is sent. Server validates oid + hc +
-//      state, atomically burns the handoff, returns {screenShareUrl, ariToken, expiresAtUtc}.
-//   5. Derive computerUrl = screenShareUrl with the trailing /screenshare stripped — pass
-//      the ARI URL verbatim per PARTNER_GUIDE (api-version stays in the URL). Pass
-//      viewerUrl = `{cdnOrigin}/screenshare-sdk/{sdkVersion}` so the iframe is loaded from
-//      the CDN (origin already allowlisted by ARI — no partner-side CORS).
-//   6. new ScreenShareViewer({container, computerUrl, viewerUrl, mode: 'interactive'}).
-//   7. viewer.connect(ariToken). Wire Take / Release / Stop buttons + status / error events.
-//
-// Sample limitations (documented in README):
-//   - One screenshare session = one ARI token lifetime (~90 min). No re-mint.
-//     On TOKEN_EXPIRED, ask the user to end + restart the W365 session.
-//   - Authentication is selected by ScreenShare:AuthMode (reported via /config):
-//       * EasyAuth  — the page is protected at the platform level by Azure App
-//         Service Authentication; the EasyAuth session cookie rides the same-origin
-//         token request and the server reads the user's oid from the injected
-//         X-MS-CLIENT-PRINCIPAL-ID header. (Production.)
-//       * DevBypass — local/Playground only; the server skips the owner check so the
-//         page works in a plain browser tab. A banner makes this obvious.
-//     Teams SSO (page embedded in Teams as a tab/dialog/stage) is a documented
-//     future extension and is not implemented in this sample.
+// The screenshare session lasts one ARI token lifetime; there is no re-mint. On
+// TOKEN_EXPIRED, the user asks the agent for a new link.
 
 (function () {
     'use strict';
@@ -53,8 +31,8 @@
         errorEl.textContent = detail ? String(detail) : '';
     }
 
-    // DEV-ONLY visual cue: when the server reports AuthMode=DevBypass the viewer's
-    // identity (owner) check is skipped, so make that unmistakable in the UI.
+    // DEV-ONLY visual cue: when the server reports AuthMode=DevBypass the user
+    // identity check is skipped, so make that unmistakable in the UI.
     function showDevBypassBanner() {
         var banner = document.createElement('div');
         banner.textContent = 'DEV BYPASS — user identity check is disabled. Local/Playground testing only.';
@@ -95,11 +73,6 @@
             var src = cdnOrigin + '/screenshare-sdk/' + encodeURIComponent(sdkVersion) + '/screenshare-embed.js';
             var s = document.createElement('script');
             s.src = src;
-            // Intentionally no crossOrigin attribute — the public CDN does not
-            // serve Access-Control-Allow-Origin for opaque script loads. Without
-            // crossorigin, the browser fetches/executes the script normally. SRI
-            // (PARTNER_GUIDE recommends for prod) does require crossorigin and
-            // CDN ACAO support; revisit when the prod CDN exposes both.
             s.onload  = function () {
                 if (typeof window.ScreenShareViewer === 'function') resolve();
                 else reject(new Error('SDK loaded but ScreenShareViewer global missing'));
@@ -118,16 +91,15 @@
             credentials: 'same-origin',
             body: JSON.stringify({ hc: params.hc })
         }).then(function (resp) {
-            if (resp.status === 401) {
-                fatal('Not signed in',
-                      'Your sign-in session has expired. Reload this page to sign in again, or reopen the link from chat.');
-            }
-            if (!resp.ok) {
-                // Surface the HTTP status; body is intentionally generic from the server.
-                return resp.text().then(function (text) {
-                    fatal('Token exchange failed (' + resp.status + ')', text || resp.statusText);
-                });
-            }
+        if (resp.status === 401) {
+            fatal('Not signed in',
+                  'Your sign-in session has expired. Reload this page to sign in again, or reopen the link from chat.');
+        }
+        if (!resp.ok) {
+            return resp.text().then(function (text) {
+                fatal('Token exchange failed (' + resp.status + ')', text || resp.statusText);
+            });
+        }
             return resp.json();
         });
     }
@@ -136,9 +108,8 @@
         var screenShareUrl = payload.screenShareUrl;
         var ariToken       = payload.ariToken;
 
-        // SDK 1.0.0 takes computerUrl verbatim (api-version preserved). The platform returns
-        //   https://{pool}.{region}.../computers/{sessionId}/screenshare?api-version=1.0
-        // but the SDK appends /screenshare itself — strip the trailing segment if present.
+        // The SDK appends /screenshare to computerUrl itself — strip a trailing
+        // /screenshare from the platform URL if present.
         var computerUrl;
         try {
             var u = new URL(screenShareUrl);
@@ -174,7 +145,6 @@
         viewer.on('error', function (code, message) {
             console.error('[screenshare] error', code, message);
             if (code === 'TOKEN_EXPIRED') {
-                // Sample limitation: no out-of-turn re-mint. User restarts the W365 session.
                 setStatus('Session expired', true);
                 setError('Please end this session and start a new one from the agent to get a fresh screen share link.');
                 takeBtn.disabled = releaseBtn.disabled = stopBtn.disabled = true;
@@ -190,10 +160,7 @@
             console.log('[screenshare] stop() called');
             viewer.stop();
             setStatus('Session stopped');
-            // Hint to the user how to get back in — the link they clicked is single-use,
-            // so the only path back is to ask the agent for a new one. The agent listens
-            // for any "screen share" + intent word (link / new / again / resend / …) and
-            // re-mints a fresh handoff for the active W365 session.
+            // The link is single-use — the only way back is to ask the agent for a new one.
             setError('To reconnect, ask the agent in chat for a new screen share link (e.g. "give me a new screen share link" or "resend the screen share link"). You can close this tab.');
             takeBtn.disabled = releaseBtn.disabled = stopBtn.disabled = true;
         });

--- a/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.js
+++ b/dotnet/w365-computer-use/sample-agent/wwwroot/screenshare.js
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// W365 Screen Share SPA bootstrap (SDK 1.0.0 public, agent-delegated user-token flow).
+//
+// Flow:
+//   1. Read sid + hc from querystring (the only two params the agent puts in the link).
+//   2. Fetch /api/screenshare/config — gets {cdnOrigin, sdkVersion}.
+//   3. Dynamically <script src=`{cdnOrigin}/screenshare-sdk/{sdkVersion}/screenshare-embed.js`>.
+//   4. POST /api/screenshare/{sid}/token with {hc} body. The page sits behind Azure
+//      App Service Authentication (EasyAuth), so the request carries the EasyAuth
+//      session cookie automatically (same-origin) and the server reads the user's
+//      object id from the X-MS-CLIENT-PRINCIPAL-ID header EasyAuth injects. No
+//      Authorization header / Teams SSO token is sent. Server validates oid + hc +
+//      state, atomically burns the handoff, returns {screenShareUrl, ariToken, expiresAtUtc}.
+//   5. Derive computerUrl = screenShareUrl with the trailing /screenshare stripped — pass
+//      the ARI URL verbatim per PARTNER_GUIDE (api-version stays in the URL). Pass
+//      viewerUrl = `{cdnOrigin}/screenshare-sdk/{sdkVersion}` so the iframe is loaded from
+//      the CDN (origin already allowlisted by ARI — no partner-side CORS).
+//   6. new ScreenShareViewer({container, computerUrl, viewerUrl, mode: 'interactive'}).
+//   7. viewer.connect(ariToken). Wire Take / Release / Stop buttons + status / error events.
+//
+// Sample limitations (documented in README):
+//   - One screenshare session = one ARI token lifetime (~90 min). No re-mint.
+//     On TOKEN_EXPIRED, ask the user to end + restart the W365 session.
+//   - Authentication is selected by ScreenShare:AuthMode (reported via /config):
+//       * EasyAuth  — the page is protected at the platform level by Azure App
+//         Service Authentication; the EasyAuth session cookie rides the same-origin
+//         token request and the server reads the user's oid from the injected
+//         X-MS-CLIENT-PRINCIPAL-ID header. (Production.)
+//       * DevBypass — local/Playground only; the server skips the owner check so the
+//         page works in a plain browser tab. A banner makes this obvious.
+//     Teams SSO (page embedded in Teams as a tab/dialog/stage) is a documented
+//     future extension and is not implemented in this sample.
+
+(function () {
+    'use strict';
+
+    var statusEl  = document.getElementById('status');
+    var errorEl   = document.getElementById('error-detail');
+    var takeBtn   = document.getElementById('btn-take');
+    var releaseBtn = document.getElementById('btn-release');
+    var stopBtn   = document.getElementById('btn-stop');
+    var container = document.getElementById('viewer');
+
+    function setStatus(text, isError) {
+        statusEl.textContent = text;
+        if (isError) statusEl.classList.add('error');
+        else statusEl.classList.remove('error');
+    }
+
+    function setError(detail) {
+        errorEl.textContent = detail ? String(detail) : '';
+    }
+
+    // DEV-ONLY visual cue: when the server reports AuthMode=DevBypass the viewer's
+    // identity (owner) check is skipped, so make that unmistakable in the UI.
+    function showDevBypassBanner() {
+        var banner = document.createElement('div');
+        banner.textContent = 'DEV BYPASS — user identity check is disabled. Local/Playground testing only.';
+        banner.style.cssText = 'background:#fde7e9;color:#a4262c;border:1px solid #a4262c;'
+            + 'border-radius:4px;padding:8px 12px;margin-bottom:12px;font-size:12px;font-weight:600;';
+        document.body.insertBefore(banner, document.body.firstChild);
+    }
+
+    function fatal(message, detail) {
+        setStatus(message, true);
+        setError(detail);
+        takeBtn.disabled = releaseBtn.disabled = stopBtn.disabled = true;
+        throw new Error(message);
+    }
+
+    function readParams() {
+        var qp = new URLSearchParams(window.location.search);
+        var sid = qp.get('sid');
+        var hc  = qp.get('hc');
+        if (!sid || !hc) {
+            fatal('Missing required parameters',
+                  'Open this page from the link the agent posts in chat. Expected ?sid=...&hc=...');
+        }
+        return { sid: sid, hc: hc };
+    }
+
+    function fetchConfig() {
+        return fetch('/api/screenshare/config', { method: 'GET' })
+            .then(function (r) {
+                if (!r.ok) { fatal('Config fetch failed (' + r.status + ')', r.statusText); }
+                return r.json();
+            });
+    }
+
+    function loadSdk(cdnOrigin, sdkVersion) {
+        return new Promise(function (resolve, reject) {
+            if (typeof window.ScreenShareViewer === 'function') { resolve(); return; }
+            var src = cdnOrigin + '/screenshare-sdk/' + encodeURIComponent(sdkVersion) + '/screenshare-embed.js';
+            var s = document.createElement('script');
+            s.src = src;
+            // Intentionally no crossOrigin attribute — the public CDN does not
+            // serve Access-Control-Allow-Origin for opaque script loads. Without
+            // crossorigin, the browser fetches/executes the script normally. SRI
+            // (PARTNER_GUIDE recommends for prod) does require crossorigin and
+            // CDN ACAO support; revisit when the prod CDN exposes both.
+            s.onload  = function () {
+                if (typeof window.ScreenShareViewer === 'function') resolve();
+                else reject(new Error('SDK loaded but ScreenShareViewer global missing'));
+            };
+            s.onerror = function () { reject(new Error('SDK script load failed: ' + src)); };
+            document.head.appendChild(s);
+        });
+    }
+
+    function exchangeToken(params) {
+        return fetch('/api/screenshare/' + encodeURIComponent(params.sid) + '/token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            // Same-origin fetch — the EasyAuth session cookie rides along so the
+            // server can read the authenticated user's object id.
+            credentials: 'same-origin',
+            body: JSON.stringify({ hc: params.hc })
+        }).then(function (resp) {
+            if (resp.status === 401) {
+                fatal('Not signed in',
+                      'Your sign-in session has expired. Reload this page to sign in again, or reopen the link from chat.');
+            }
+            if (!resp.ok) {
+                // Surface the HTTP status; body is intentionally generic from the server.
+                return resp.text().then(function (text) {
+                    fatal('Token exchange failed (' + resp.status + ')', text || resp.statusText);
+                });
+            }
+            return resp.json();
+        });
+    }
+
+    function startViewer(cfg, payload) {
+        var screenShareUrl = payload.screenShareUrl;
+        var ariToken       = payload.ariToken;
+
+        // SDK 1.0.0 takes computerUrl verbatim (api-version preserved). The platform returns
+        //   https://{pool}.{region}.../computers/{sessionId}/screenshare?api-version=1.0
+        // but the SDK appends /screenshare itself — strip the trailing segment if present.
+        var computerUrl;
+        try {
+            var u = new URL(screenShareUrl);
+            u.pathname = u.pathname.replace(/\/screenshare\/?$/i, '');
+            computerUrl = u.toString();
+        } catch (e) { fatal('Invalid screenShareUrl from server', e.message); }
+
+        var viewerUrl = cfg.cdnOrigin + '/screenshare-sdk/' + cfg.sdkVersion;
+
+        setStatus('Connecting…');
+
+        var viewer = new window.ScreenShareViewer({
+            container:   container,
+            computerUrl: computerUrl,
+            viewerUrl:   viewerUrl,
+            mode:        'interactive'
+        });
+
+        viewer.on('statusChanged', function (state, message) {
+            console.log('[screenshare] statusChanged →', state, message || '');
+            switch (state) {
+                case 'connecting':    setStatus('Connecting…'); break;
+                case 'connected':     setStatus('Connected (view-only)'); takeBtn.disabled = false; stopBtn.disabled = false; releaseBtn.disabled = true; break;
+                case 'controlling':   setStatus('Connected (controlling)'); takeBtn.disabled = true; releaseBtn.disabled = false; stopBtn.disabled = false; break;
+                case 'view-only':     setStatus('Connected (view-only)'); takeBtn.disabled = false; releaseBtn.disabled = true; break;
+                case 'reconnecting':  setStatus('Reconnecting…'); break;
+                case 'reconnected':   setStatus('Reconnected'); break;
+                case 'disconnected':  setStatus('Disconnected'); takeBtn.disabled = releaseBtn.disabled = stopBtn.disabled = true; break;
+                default:              setStatus(state + (message ? ': ' + message : ''));
+            }
+        });
+
+        viewer.on('error', function (code, message) {
+            console.error('[screenshare] error', code, message);
+            if (code === 'TOKEN_EXPIRED') {
+                // Sample limitation: no out-of-turn re-mint. User restarts the W365 session.
+                setStatus('Session expired', true);
+                setError('Please end this session and start a new one from the agent to get a fresh screen share link.');
+                takeBtn.disabled = releaseBtn.disabled = stopBtn.disabled = true;
+                return;
+            }
+            setStatus('Error: ' + code, true);
+            setError(message || '');
+        });
+
+        takeBtn.addEventListener('click', function () { console.log('[screenshare] takeControl() called'); viewer.takeControl(); });
+        releaseBtn.addEventListener('click', function () { console.log('[screenshare] releaseControl() called'); viewer.releaseControl(); });
+        stopBtn.addEventListener('click', function () {
+            console.log('[screenshare] stop() called');
+            viewer.stop();
+            setStatus('Session stopped');
+            // Hint to the user how to get back in — the link they clicked is single-use,
+            // so the only path back is to ask the agent for a new one. The agent listens
+            // for any "screen share" + intent word (link / new / again / resend / …) and
+            // re-mints a fresh handoff for the active W365 session.
+            setError('To reconnect, ask the agent in chat for a new screen share link (e.g. "give me a new screen share link" or "resend the screen share link"). You can close this tab.');
+            takeBtn.disabled = releaseBtn.disabled = stopBtn.disabled = true;
+        });
+
+        return viewer.connect(ariToken);
+    }
+
+    // ---------- Bootstrap ----------
+    var params = readParams();
+
+    setStatus('Loading SDK…');
+    var cfg;
+    fetchConfig()
+        .then(function (c) {
+            cfg = c;
+            if (!cfg.cdnOrigin || !cfg.sdkVersion) {
+                fatal('Server config missing cdnOrigin or sdkVersion');
+            }
+            if (cfg.authMode === 'DevBypass') {
+                showDevBypassBanner();
+            }
+            return loadSdk(cfg.cdnOrigin, cfg.sdkVersion);
+        })
+        .then(function () {
+            setStatus('Authorizing…');
+            return exchangeToken(params);
+        })
+        .then(function (payload) {
+            if (!payload) return;
+            setStatus('Mounting viewer…');
+            return startViewer(cfg, payload);
+        })
+        .catch(function (err) {
+            console.error('[screenshare] fatal', err);
+            setStatus('Failed to start screenshare', true);
+            setError((err && err.message) || String(err));
+        });
+})();


### PR DESCRIPTION
## Summary

Ports the live **screenshare** feature into the `w365-computer-use` sample so the agent can expose a link to the running Cloud PC through the W365 / ARI screenshare SDK. The SDK is loaded from the public Microsoft CDN (`https://packages.global.cloudinferenceplatform.azure.com`).

## What changed

**New files**
- `ScreenShare/ScreenShareOptions.cs` — configuration options (auth mode, SDK version, CDN origin, page base URL, allowed frame ancestors).
- `ScreenShare/HandoffStore.cs` — in-memory one-time handoff store (session id, screenShareUrl, owner oid, hashed handoff code, ARI token + expiry).
- `wwwroot/screenshare.html`, `wwwroot/screenshare.js` — SPA that loads the SDK from the configured CDN origin.

**Modified**
- `ComputerUse/W365McpSessionClient.cs` — capture `screenShareUrl` from the start-session response.
- `ComputerUse/ComputerUseOrchestrator.cs` — track `screenShareUrl` per session, add `onScreenShareLinkReady` callback + prestarted-URL threading, and `TryGetActiveScreenShare[Async]` lookups.
- `Agent/MyAgent.cs` — mint the ARI token, build the screenshare page link, handle the re-mint fast path.
- `Program.cs` — DI registrations, rate limiting, static files + CSP `frame-ancestors`, `/api/screenshare/config` and token endpoints, dev HTTPS listener (`https://localhost:3979`), EasyAuth principal helper.
- `appsettings.json` — `ari` auth handler + `ScreenShare` config section.
- `README.md` — screenshare setup and configuration reference.

## Notes
- `ScreenShare:PageBaseUrl` is a placeholder; the CDN origin and ARI scope (`90ecec28-f5a6-42b3-9bde-dae1ca98f8b5/.default`) are public, non-secret defaults.
- Local testing: bind `https://localhost:3979`, set `ScreenShare:AuthMode=DevBypass` and `ARI_BEARER_TOKEN`.